### PR TITLE
Prevent fatal errors for the plugins

### DIFF
--- a/administrator/components/com_media/controllers/editor.php
+++ b/administrator/components/com_media/controllers/editor.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+require_once JPATH_COMPONENT . '/controller.php';
 require_once JPATH_COMPONENT . '/helpers/editor.php';
 
 /**


### PR DESCRIPTION
@jissereitsma check this patch, to solve the fatal errors in the editor plugins

#### Summary of Changes

#### Testing Instructions

Class MediaController not found (not loaded).