### PR TITLE
Simplify the process event, sending the local file path

### DIFF
--- a/administrator/components/com_media/libraries/media/file/adapter/interface.php
+++ b/administrator/components/com_media/libraries/media/file/adapter/interface.php
@@ -90,14 +90,14 @@ interface MediaFileAdapterInterface
 	public function delete($path);
 
 	/**
-	 * Returns a stream for the given path.
+	 * Returns a file in the local filesystem for the given path.
 	 *
 	 * @param   string  $path  The path to the file
 	 *
-	 * @return  resource  The resource
+	 * @return  string  The local file path
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception
 	 */
-	public function getStream($path);
+	public function getLocalFilePath($path);
 }

--- a/administrator/components/com_media/libraries/media/file/adapter/local.php
+++ b/administrator/components/com_media/libraries/media/file/adapter/local.php
@@ -199,17 +199,17 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 	}
 
 	/**
-	 * Returns a stream for the given path.
+	 * Returns a file in the local filesystem for the given path.
 	 *
 	 * @param   string  $path  The path to the file
 	 *
-	 * @return  resource  The resource
+	 * @return  string  The local file path
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception
 	 */
-	public function getStream($path)
+	public function getLocalFilePath($path)
 	{
-		return fopen($this->rootPath . $path, 'rw');
+		return JPath::clean($this->rootPath . $path);
 	}
 }

--- a/tests/unit/suites/administrator/components/com_media/libraries/file/LocalAdapterTest.php
+++ b/tests/unit/suites/administrator/components/com_media/libraries/file/LocalAdapterTest.php
@@ -254,11 +254,11 @@ class LocalAdapterTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test MediaFileAdapterLocal::getStream
+	 * Test MediaFileAdapterLocal::getLocalFilePath
 	 *
 	 * @return  void
 	 */
-	public function testGetStream()
+	public function testGetLocalFilePath()
 	{
 		// Make some test files
 		JFile::write($this->root . 'test.txt', 'test');
@@ -266,10 +266,10 @@ class LocalAdapterTest extends PHPUnit_Framework_TestCase
 		// Create the adapter
 		$adapter = new MediaFileAdapterLocal($this->root);
 
-		// Fetch the resource for the test file
-		$resource = $adapter->getStream('test.txt');
+		// Fetch the path for the test file
+		$path = $adapter->getLocalFilePath('test.txt');
 
-		// Check if it is a resource
-		$this->assertTrue(is_resource($resource));
+		// Check if the paths are equal
+		$this->assertEquals($this->root . 'test.txt', $path);
 	}
 }


### PR DESCRIPTION
In the original pr #76 the _onMediaProcess_ event is triggered with a resource object. This is very much tailored to images. This pr uses a local file system path instead.

Pros:
- It will make the event more understandable for developers.
- Libraries which are file based are supported.

Cons:
- Every plugin does probably a file open and close.