### PR TITLE
Input check and more stable

### DIFF
--- a/administrator/components/com_media/controllers/api.json.php
+++ b/administrator/components/com_media/controllers/api.json.php
@@ -82,19 +82,18 @@ class MediaControllerApi extends Controller
 		$path = $this->input->getPath('path', '/', 'path');
 
 		// Determine the method
-		$method = $this->input->getMethod() ? : 'GET';
-
-		// Check token for requests which do modify files
-		if (in_array(strtolower($method), array('post', 'put', 'delete')) && !JSession::checkToken('request'))
-		{
-			$this->sendResponse(new Exception(JText::_('JINVALID_TOKEN'), 403));
-			return;
-		}
+		$method = strtolower($this->input->getMethod() ? : 'GET');
 
 		try
 		{
+			// Check token for requests which do modify files (all except get requests)
+			if ($method !== 'get' && !JSession::checkToken('request'))
+			{
+				throw new InvalidArgumentException(JText::_('JINVALID_TOKEN'), 403);
+			}
+
 			// Gather the data according to the method
-			switch (strtolower($method))
+			switch ($method)
 			{
 				case 'get':
 					$data = $this->getModel()->getFiles($path, $this->input->getWord('filter'));

--- a/administrator/components/com_media/controllers/api.json.php
+++ b/administrator/components/com_media/controllers/api.json.php
@@ -87,7 +87,7 @@ class MediaControllerApi extends Controller
 		try
 		{
 			// Check token for requests which do modify files (all except get requests)
-			if ($method !== 'get' && !JSession::checkToken('request'))
+			if ($method != 'get' && !JSession::checkToken('request'))
 			{
 				throw new InvalidArgumentException(JText::_('JINVALID_TOKEN'), 403);
 			}

--- a/administrator/components/com_media/controllers/api.json.php
+++ b/administrator/components/com_media/controllers/api.json.php
@@ -109,10 +109,8 @@ class MediaControllerApi extends JControllerLegacy
 	 */
 	public function files()
 	{
-		// @todo add ACL check
-
 		// Get the required variables
-		$path = $this->input->getPath('path', '/');
+		$path = $this->input->getPath('path', '/', 'path');
 
 		// Determine the method
 		$method = $this->input->getMethod() ? : 'GET';
@@ -130,11 +128,13 @@ class MediaControllerApi extends JControllerLegacy
 					break;
 				case 'post':
 					$content      = $this->input->json;
-					$name         = $content->get('name');
+					$name         = $this->getSafeName($content->get('name'));
 					$mediaContent = base64_decode($content->get('content'));
 
 					if ($mediaContent)
 					{
+						$this->checkContent($name, $mediaContent);
+
 						// A file needs to be created
 						$this->adapter->createFile($name, $path, $mediaContent);
 					}
@@ -150,6 +150,8 @@ class MediaControllerApi extends JControllerLegacy
 					$content      = $this->input->json;
 					$name         = basename($path);
 					$mediaContent = base64_decode($content->get('content'));
+
+					$this->checkContent($name, $mediaContent);
 
 					$this->adapter->updateFile($name, str_replace($name, '', $path), $mediaContent);
 
@@ -168,7 +170,13 @@ class MediaControllerApi extends JControllerLegacy
 		}
 		catch (Exception $e)
 		{
-			$this->sendResponse($e, 500);
+			$errorCode = 500;
+
+			if ($e->getCode() > 0)
+			{
+				$errorCode = $e->getCode();
+			}
+			$this->sendResponse($e, $errorCode);
 		}
 	}
 
@@ -194,5 +202,80 @@ class MediaControllerApi extends JControllerLegacy
 
 		// Send the data
 		echo new JResponseJson($data);
+	}
+
+
+	/**
+	 * Creates a safe file name for the given name.
+	 *
+	 * @param   string  $name  The filename
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 */
+	private function getSafeName($name)
+	{
+		// Make the filename safe
+		$name = JFile::makeSafe($name);
+
+		// Transform filename to punycode
+		$name = JStringPunycode::toPunycode($name);
+
+		$extension = JFile::getExt($name);
+
+		if ($extension)
+		{
+			$extension = '.' . strtolower($extension);
+		}
+
+		// Transform filename to punycode, then neglect other than non-alphanumeric characters & underscores.
+		// Also transform extension to lowercase.
+		$name = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $name) . $extension;
+
+		return $name;
+	}
+
+	/**
+	 * Performs various check if it is allowed to save the content with the given name.
+	 *
+	 * @param   string  $name          The filename
+	 * @param   string  $mediaContent  The media content
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 */
+	private function checkContent($name, $mediaContent)
+	{
+		if (!JFactory::getUser()->authorise('core.create', 'com_media'))
+		{
+			throw new Exception(JText::_('COM_MEDIA_ERROR_CREATE_NOT_PERMITTED'), 403);
+		}
+
+		$helper = new JHelperMedia();
+		$serverlength = $this->input->server->get('CONTENT_LENGTH');
+		if ($serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024)
+			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
+			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))
+			|| $serverlength > $helper->toBytes(ini_get('memory_limit')))
+		{
+			throw new Exception(JText::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'));
+		}
+
+		// @todo find a better way to check the input, by not writing the file to the disk
+		$tmpFile = JFactory::getApplication()->getConfig()->get('tmp_path') . '/' . uniqid($name);
+
+		if (!JFile::write($tmpFile, $mediaContent))
+		{
+			throw new Exception(JText::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'));
+		}
+
+		if (!$helper->canUpload(array('name' => $name, 'size' => sizeof($mediaContent), 'tmp_name' => $tmpFile), 'com_media'))
+		{
+			throw new Exception(JText::_('COM_MEDIA_ERROR_UNABLE_TO_UPLOAD_FILE'), 403);
+		}
 	}
 }

--- a/administrator/components/com_media/controllers/api.json.php
+++ b/administrator/components/com_media/controllers/api.json.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Cms\Controller\Controller;
+
 /**
  * Api Media Controller
  *
@@ -16,41 +18,8 @@ defined('_JEXEC') or die;
  *
  * @since  __DEPLOY_VERSION__
  */
-class MediaControllerApi extends JControllerLegacy
+class MediaControllerApi extends Controller
 {
-	/**
-	 * The local file adapter to work with.
-	 *
-	 * @var MediaFileAdapterInterface
-	 */
-	protected $adapter = null;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param   array  $config  An optional associative array of configuration settings.
-	 * Recognized key values include 'name', 'default_task', 'model_path', and
-	 * 'view_path' (this list is not meant to be comprehensive).
-	 *
-	 * @since   3.0
-	 */
-	public function __construct($config = array())
-	{
-		parent::__construct($config);
-
-		if (!isset($config['fileadapter']))
-		{
-			// Compile the root path
-			$root = JPATH_ROOT . '/' . JComponentHelper::getParams('com_media')->get('file_path', 'images');
-			$root = rtrim($root) . '/';
-
-			// Default to the local adapter
-			$config['fileadapter'] = new MediaFileAdapterLocal($root);
-		}
-
-		$this->adapter = $config['fileadapter'];
-	}
-
 	/**
 	 * Api endpoint for the media manager front end. The HTTP methods GET, PUT, POST and DELETE
 	 * are supported.
@@ -115,47 +84,50 @@ class MediaControllerApi extends JControllerLegacy
 		// Determine the method
 		$method = $this->input->getMethod() ? : 'GET';
 
+		// Check token for requests which do modify files
+		if (in_array(strtolower($method), array('post', 'put', 'delete')) && !JSession::checkToken('request'))
+		{
+			$this->sendResponse(new Exception(JText::_('JINVALID_TOKEN'), 403));
+			return;
+		}
+
 		try
 		{
-			// Gather the data accoring to the method
+			// Gather the data according to the method
 			switch (strtolower($method))
 			{
 				case 'get':
-					$data = $this->adapter->getFiles($path, $this->input->getWord('filter'));
+					$data = $this->getModel()->getFiles($path, $this->input->getWord('filter'));
 					break;
 				case 'delete':
-					$this->adapter->delete($path);
+					$this->getModel()->delete($path);
 					break;
 				case 'post':
 					$content      = $this->input->json;
-					$name         = $this->getSafeName($content->get('name'));
+					$name         = $content->get('name');
 					$mediaContent = base64_decode($content->get('content'));
 
 					if ($mediaContent)
 					{
-						$this->checkContent($name, $mediaContent);
-
 						// A file needs to be created
-						$this->adapter->createFile($name, $path, $mediaContent);
+						$this->getModel()->createFile($name, $path, $mediaContent);
 					}
 					else
 					{
 						// A file needs to be created
-						$this->adapter->createFolder($name, $path);
+						$this->getModel()->createFolder($name, $path);
 					}
 
-					$data = $this->adapter->getFile($path . '/' . $name);
+					$data = $this->getModel()->getFile($path . '/' . $name);
 					break;
 				case 'put':
 					$content      = $this->input->json;
 					$name         = basename($path);
 					$mediaContent = base64_decode($content->get('content'));
 
-					$this->checkContent($name, $mediaContent);
+					$this->getModel()->updateFile($name, str_replace($name, '', $path), $mediaContent);
 
-					$this->adapter->updateFile($name, str_replace($name, '', $path), $mediaContent);
-
-					$data = $this->adapter->getFile($path . '/' . $name);
+					$data = $this->getModel()->getFile($path . '/' . $name);
 					break;
 				default:
 					throw new BadMethodCallException('Method not supported yet!');
@@ -204,78 +176,19 @@ class MediaControllerApi extends JControllerLegacy
 		echo new JResponseJson($data);
 	}
 
-
 	/**
-	 * Creates a safe file name for the given name.
+	 * Method to get a model object, loading it if required.
 	 *
-	 * @param   string  $name  The filename
+	 * @param   string  $name    The model name. Optional.
+	 * @param   string  $prefix  The class prefix. Optional.
+	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  string
+	 * @return  Model|boolean  Model object on success; otherwise false on failure.
 	 *
-	 * @since   __DEPLOY_VERSION__
-	 * @throws  Exception
+	 * @since   3.0
 	 */
-	private function getSafeName($name)
+	public function getModel($name = 'Api', $prefix = 'MediaModel', $config = array())
 	{
-		// Make the filename safe
-		$name = JFile::makeSafe($name);
-
-		// Transform filename to punycode
-		$name = JStringPunycode::toPunycode($name);
-
-		$extension = JFile::getExt($name);
-
-		if ($extension)
-		{
-			$extension = '.' . strtolower($extension);
-		}
-
-		// Transform filename to punycode, then neglect other than non-alphanumeric characters & underscores.
-		// Also transform extension to lowercase.
-		$name = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $name) . $extension;
-
-		return $name;
-	}
-
-	/**
-	 * Performs various check if it is allowed to save the content with the given name.
-	 *
-	 * @param   string  $name          The filename
-	 * @param   string  $mediaContent  The media content
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 * @throws  Exception
-	 */
-	private function checkContent($name, $mediaContent)
-	{
-		if (!JFactory::getUser()->authorise('core.create', 'com_media'))
-		{
-			throw new Exception(JText::_('COM_MEDIA_ERROR_CREATE_NOT_PERMITTED'), 403);
-		}
-
-		$helper = new JHelperMedia();
-		$serverlength = $this->input->server->get('CONTENT_LENGTH');
-		if ($serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024)
-			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
-			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))
-			|| $serverlength > $helper->toBytes(ini_get('memory_limit')))
-		{
-			throw new Exception(JText::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'));
-		}
-
-		// @todo find a better way to check the input, by not writing the file to the disk
-		$tmpFile = JFactory::getApplication()->getConfig()->get('tmp_path') . '/' . uniqid($name);
-
-		if (!JFile::write($tmpFile, $mediaContent))
-		{
-			throw new Exception(JText::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'));
-		}
-
-		if (!$helper->canUpload(array('name' => $name, 'size' => sizeof($mediaContent), 'tmp_name' => $tmpFile), 'com_media'))
-		{
-			throw new Exception(JText::_('COM_MEDIA_ERROR_UNABLE_TO_UPLOAD_FILE'), 403);
-		}
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_media/libraries/media/file/adapter/local.php
+++ b/administrator/components/com_media/libraries/media/file/adapter/local.php
@@ -189,6 +189,11 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 	 */
 	public function updateFile($name, $path, $data)
 	{
+		if (!JFile::exists($this->rootPath . $path . '/' . $name))
+		{
+			throw new MediaFileAdapterFilenotfoundexception();
+		}
+
 		JFile::write($this->rootPath . $path . '/' . $name, $data);
 	}
 
@@ -209,10 +214,20 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 
 		if (is_file($this->rootPath . $path))
 		{
+			if (!JFile::exists($this->rootPath . $path))
+			{
+				throw new MediaFileAdapterFilenotfoundexception();
+			}
+
 			$success = JFile::delete($this->rootPath . $path);
 		}
 		else
 		{
+			if (!JFolder::exists($this->rootPath . $path))
+			{
+				throw new MediaFileAdapterFilenotfoundexception();
+			}
+
 			$success = JFolder::delete($this->rootPath . $path);
 		}
 

--- a/administrator/components/com_media/models/api.php
+++ b/administrator/components/com_media/models/api.php
@@ -213,8 +213,11 @@ class MediaModelApi extends Model
 			throw new Exception(JText::_('COM_MEDIA_ERROR_CREATE_NOT_PERMITTED'), 403);
 		}
 
+		$params = JComponentHelper::getParams('com_media');
+
 		$helper = new JHelperMedia();
 		$serverlength = $this->input->server->get('CONTENT_LENGTH');
+
 		if ($serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024)
 			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
 			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))

--- a/administrator/components/com_media/models/api.php
+++ b/administrator/components/com_media/models/api.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Cms\Model\Model;
+
+/**
+ * Api Model
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class MediaModelApi extends Model
+{
+	/**
+	 * The local file adapter to work with.
+	 *
+	 * @var MediaFileAdapterInterface
+	 */
+	protected $adapter = null;
+	/**
+	 * Constructor
+	 *
+	 * @param   array  $config  An array of configuration options (name, state, dbo, table_path, ignore_request).
+	 *
+	 * @since   3.0
+	 * @throws  \Exception
+	 */
+	public function __construct($config = array())
+	{
+		parent::__construct($config);
+
+		if (!isset($config['fileadapter']))
+		{
+			// Compile the root path
+			$root = JPATH_ROOT . '/' . JComponentHelper::getParams('com_media')->get('file_path', 'images');
+			$root = rtrim($root) . '/';
+
+			// Default to the local adapter
+			$config['fileadapter'] = new MediaFileAdapterLocal($root);
+		}
+
+		$this->adapter = $config['fileadapter'];
+	}
+
+	/**
+	 * Returns the requested file or folder information. More information
+	 * can be found in MediaFileAdapterInterface::getFile().
+	 *
+	 * @param   string  $path  The path to the file or folder
+	 *
+	 * @return  stdClass[]
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 * @see     MediaFileAdapterInterface::getFile()
+	 */
+	public function getFile($path = '/')
+	{
+		return $this->adapter->getFile($path);
+	}
+
+	/**
+	 * Returns the folders and files for the given path. More information
+	 * can be found in MediaFileAdapterInterface::getFiles().
+	 *
+	 * @param   string  $path    The folder
+	 * @param   string  $filter  The filter
+	 *
+	 * @return  stdClass[]
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 * @see     MediaFileAdapterInterface::getFile()
+	 */
+	public function getFiles($path = '/', $filter = '')
+	{
+		return $this->adapter->getFiles($path, $filter);
+	}
+
+	/**
+	 * Creates a folder with the given name in the given path. More information
+	 * can be found in MediaFileAdapterInterface::createFolder().
+	 *
+	 * @param   string  $name  The name
+	 * @param   string  $path  The folder
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 * @see     MediaFileAdapterInterface::createFolder()
+	 */
+	public function createFolder($name, $path)
+	{
+		$this->adapter->createFolder($name, $path);
+	}
+
+	/**
+	 * Creates a file with the given name in the given path with the data. More information
+	 * can be found in MediaFileAdapterInterface::createFile().
+	 *
+	 * @param   string  $name  The name
+	 * @param   string  $path  The folder
+	 * @param   binary  $data  The data
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 * @see     MediaFileAdapterInterface::createFile()
+	 */
+	public function createFile($name, $path, $data)
+	{
+		$name = $this->getSafeName($name);
+
+		$this->checkContent($name, $data);
+
+		$this->adapter->createFile($name, $path, $data);
+	}
+
+	/**
+	 * Updates the file with the given name in the given path with the data. More information
+	 * can be found in MediaFileAdapterInterface::updateFile().
+	 *
+	 * @param   string  $name  The name
+	 * @param   string  $path  The folder
+	 * @param   binary  $data  The data
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 * @see     MediaFileAdapterInterface::updateFile()
+	 */
+	public function updateFile($name, $path, $data)
+	{
+		$this->checkContent($name, $data);
+
+		$this->adapter->updateFile($name, $path, $data);
+	}
+
+	/**
+	 * Deletes the folder or file of the given path. More information
+	 * can be found in MediaFileAdapterInterface::delete().
+	 *
+	 * @param   string  $path  The path to the file or folder
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 * @see     MediaFileAdapterInterface::delete()
+	 */
+	public function delete($path)
+	{
+		$this->adapter->delete($path);
+	}
+
+	/**
+	 * Creates a safe file name for the given name.
+	 *
+	 * @param   string  $name  The filename
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 */
+	private function getSafeName($name)
+	{
+		// Make the filename safe
+		$name = JFile::makeSafe($name);
+
+		// Transform filename to punycode
+		$name = JStringPunycode::toPunycode($name);
+
+		$extension = JFile::getExt($name);
+
+		if ($extension)
+		{
+			$extension = '.' . strtolower($extension);
+		}
+
+		// Transform filename to punycode, then neglect other than non-alphanumeric characters & underscores.
+		// Also transform extension to lowercase.
+		$name = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $name) . $extension;
+
+		return $name;
+	}
+
+	/**
+	 * Performs various check if it is allowed to save the content with the given name.
+	 *
+	 * @param   string  $name          The filename
+	 * @param   string  $mediaContent  The media content
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 */
+	private function checkContent($name, $mediaContent)
+	{
+		if (!JFactory::getUser()->authorise('core.create', 'com_media'))
+		{
+			throw new Exception(JText::_('COM_MEDIA_ERROR_CREATE_NOT_PERMITTED'), 403);
+		}
+
+		$helper = new JHelperMedia();
+		$serverlength = $this->input->server->get('CONTENT_LENGTH');
+		if ($serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024)
+			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
+			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))
+			|| $serverlength > $helper->toBytes(ini_get('memory_limit')))
+		{
+			throw new Exception(JText::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'));
+		}
+
+		// @todo find a better way to check the input, by not writing the file to the disk
+		$tmpFile = JFactory::getApplication()->getConfig()->get('tmp_path') . '/' . uniqid($name);
+
+		if (!JFile::write($tmpFile, $mediaContent))
+		{
+			throw new Exception(JText::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'));
+		}
+
+		if (!$helper->canUpload(array('name' => $name, 'size' => sizeof($mediaContent), 'tmp_name' => $tmpFile), 'com_media'))
+		{
+			throw new Exception(JText::_('COM_MEDIA_ERROR_UNABLE_TO_UPLOAD_FILE'), 403);
+		}
+	}
+}

--- a/administrator/components/com_media/models/api.php
+++ b/administrator/components/com_media/models/api.php
@@ -141,8 +141,6 @@ class MediaModelApi extends Model
 	 */
 	public function updateFile($name, $path, $data)
 	{
-		$this->checkContent($name, $data);
-
 		$this->adapter->updateFile($name, $path, $data);
 	}
 
@@ -193,50 +191,5 @@ class MediaModelApi extends Model
 		$name = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $name) . $extension;
 
 		return $name;
-	}
-
-	/**
-	 * Performs various check if it is allowed to save the content with the given name.
-	 *
-	 * @param   string  $name          The filename
-	 * @param   string  $mediaContent  The media content
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 * @throws  Exception
-	 */
-	private function checkContent($name, $mediaContent)
-	{
-		if (!JFactory::getUser()->authorise('core.create', 'com_media'))
-		{
-			throw new Exception(JText::_('COM_MEDIA_ERROR_CREATE_NOT_PERMITTED'), 403);
-		}
-
-		$params = JComponentHelper::getParams('com_media');
-
-		$helper = new JHelperMedia();
-		$serverlength = $this->input->server->get('CONTENT_LENGTH');
-
-		if ($serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024)
-			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
-			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))
-			|| $serverlength > $helper->toBytes(ini_get('memory_limit')))
-		{
-			throw new Exception(JText::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'));
-		}
-
-		// @todo find a better way to check the input, by not writing the file to the disk
-		$tmpFile = JFactory::getApplication()->getConfig()->get('tmp_path') . '/' . uniqid($name);
-
-		if (!JFile::write($tmpFile, $mediaContent))
-		{
-			throw new Exception(JText::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'));
-		}
-
-		if (!$helper->canUpload(array('name' => $name, 'size' => sizeof($mediaContent), 'tmp_name' => $tmpFile), 'com_media'))
-		{
-			throw new Exception(JText::_('COM_MEDIA_ERROR_UNABLE_TO_UPLOAD_FILE'), 403);
-		}
 	}
 }

--- a/tests/unit/suites/administrator/components/com_media/libraries/file/LocalAdapterTest.php
+++ b/tests/unit/suites/administrator/components/com_media/libraries/file/LocalAdapterTest.php
@@ -287,7 +287,7 @@ class LocalAdapterTest extends TestCaseDatabase
 	public function testUpdateFile()
 	{
 		// Make some test files
-		JFile::write($this->root . 'test.txt', 'test');
+		JFile::write($this->root . 'unit.txt', 'test');
 
 		// Create the adapter
 		$adapter = new MediaFileAdapterLocal($this->root);
@@ -300,6 +300,22 @@ class LocalAdapterTest extends TestCaseDatabase
 
 		// Check if the contents is correct
 		$this->assertEquals('test 2', file_get_contents($this->root . 'unit.txt'));
+	}
+
+	/**
+	 * Test MediaFileAdapterLocal::getFile with an invalid path
+	 *
+	 * @expectedException MediaFileAdapterFilenotfoundexception
+	 *
+	 * @return  void
+	 */
+	public function testUpdateFileInvalidPath()
+	{
+		// Create the adapter
+		$adapter = new MediaFileAdapterLocal($this->root);
+
+		// Fetch the file from the root folder
+		$adapter->updateFile('invalid', '/', 'test');
 	}
 
 	/**
@@ -325,5 +341,21 @@ class LocalAdapterTest extends TestCaseDatabase
 
 		// Check if the files exists
 		$this->assertCount(1, JFolder::files($this->root));
+	}
+
+	/**
+	 * Test MediaFileAdapterLocal::getFile with an invalid path
+	 *
+	 * @expectedException MediaFileAdapterFilenotfoundexception
+	 *
+	 * @return  void
+	 */
+	public function testDeleteInvalidPath()
+	{
+		// Create the adapter
+		$adapter = new MediaFileAdapterLocal($this->root);
+
+		// Fetch the file from the root folder
+		$adapter->delete('invalid');
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #88. Upload checks which are applicable with the new architecture are migrated from [old media manager upload function](https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_media/controllers/file.json.php#L29). Any feedback is welcome.

What is not done is the check for `JSession::checkToken('request'))`. Question here, should this be done for every request or only PUT and POST?
