### PR TITLE
Only fetch the width and height when it is a file

### DIFF
--- a/administrator/components/com_media/libraries/media/file/adapter/local.php
+++ b/administrator/components/com_media/libraries/media/file/adapter/local.php
@@ -280,7 +280,7 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 		$obj->width                   = 0;
 		$obj->height                  = 0;
 
-		if (strpos($obj->mime_type, 'image/' === 0) && in_array(strtolower($obj->extension), array('jpg', 'jpeg', 'png', 'gif', 'bmp')))
+		if (strpos($obj->mime_type, 'image/') === 0 && in_array(strtolower($obj->extension), array('jpg', 'jpeg', 'png', 'gif', 'bmp')))
 		{
 			// Get the image properties
 			$props       = JImage::getImageFileProperties($path);

--- a/administrator/components/com_media/libraries/media/file/adapter/local.php
+++ b/administrator/components/com_media/libraries/media/file/adapter/local.php
@@ -280,10 +280,16 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 
 		try
 		{
-			// Get the image properties
-			$props       = JImage::getImageFileProperties($path);
-			$obj->width  = $props->width;
-			$obj->height = $props->height;
+			$obj->width  = 0;
+			$obj->height = 0;
+
+			if (!is_dir($path))
+			{
+				// Get the image properties
+				$props       = JImage::getImageFileProperties($path);
+				$obj->width  = $props->width;
+				$obj->height = $props->height;
+			}
 		}
 		catch (Exception $e)
 		{

--- a/administrator/components/com_media/libraries/media/file/adapter/local.php
+++ b/administrator/components/com_media/libraries/media/file/adapter/local.php
@@ -277,25 +277,15 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 		$obj->modified_date           = $modifiedDate->format('c', true);
 		$obj->modified_date_formatted = (string) $modifiedDate; // TODO use format from config
 		$obj->mime_type               = mime_content_type($path);
+		$obj->width                   = 0;
+		$obj->height                  = 0;
 
-		try
+		if (strpos($obj->mime_type, 'image/' === 0) && in_array(strtolower($obj->extension), array('jpg', 'jpeg', 'png', 'gif', 'bmp')))
 		{
-			$obj->width  = 0;
-			$obj->height = 0;
-
-			if (!is_dir($path))
-			{
-				// Get the image properties
-				$props       = JImage::getImageFileProperties($path);
-				$obj->width  = $props->width;
-				$obj->height = $props->height;
-			}
-		}
-		catch (Exception $e)
-		{
-			// Probably not an image
-			$obj->width  = 0;
-			$obj->height = 0;
+			// Get the image properties
+			$props       = JImage::getImageFileProperties($path);
+			$obj->width  = $props->width;
+			$obj->height = $props->height;
 		}
 
 		return $obj;
@@ -316,7 +306,7 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 
 		$timezone = JFactory::getApplication()->get('offset');
 		$user     = JFactory::getUser();
-		
+
 		if ($user->id)
 		{
 			$userTimezone = $user->getParam('timezone');


### PR DESCRIPTION
When error reporting is set to maximum, then an error is thrown because the image size can't be determined on a folder. This pr fixes that.

The error is:
_Notice:  getimagesize(): Read error! in /mm/libraries/vendor/joomla/image/src/Image.php on line 215_