### PR TITLE
Use OS path separator

### DIFF
--- a/administrator/components/com_media/controllers/api.json.php
+++ b/administrator/components/com_media/controllers/api.json.php
@@ -119,7 +119,7 @@ class MediaControllerApi extends Controller
 						$name = $this->getModel()->createFolder($name, $path);
 					}
 
-					$data = $this->getModel()->getFile($path . '/' . $name);
+					$data = $this->getModel()->getFile($path . DIRECTORY_SEPARATOR . $name);
 					break;
 				case 'put':
 					$content      = $this->input->json;
@@ -130,7 +130,7 @@ class MediaControllerApi extends Controller
 
 					$this->getModel()->updateFile($name, str_replace($name, '', $path), $mediaContent);
 
-					$data = $this->getModel()->getFile($path . '/' . $name);
+					$data = $this->getModel()->getFile($path . DIRECTORY_SEPARATOR . $name);
 					break;
 				default:
 					throw new BadMethodCallException('Method not supported yet!');
@@ -227,7 +227,7 @@ class MediaControllerApi extends Controller
 		}
 
 		// @todo find a better way to check the input, by not writing the file to the disk
-		$tmpFile = JFactory::getApplication()->getConfig()->get('tmp_path') . '/' . uniqid($name);
+		$tmpFile = JFactory::getApplication()->getConfig()->get('tmp_path') . DIRECTORY_SEPARATOR . uniqid($name);
 
 		if (!JFile::write($tmpFile, $mediaContent))
 		{

--- a/administrator/components/com_media/libraries/media/file/adapter/interface.php
+++ b/administrator/components/com_media/libraries/media/file/adapter/interface.php
@@ -39,7 +39,7 @@ interface MediaFileAdapterInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception
 	 */
-	public function getFile($path = '/');
+	public function getFile($path = DIRECTORY_SEPARATOR);
 
 	/**
 	 * Returns the folders and files for the given path. The returned objects
@@ -65,7 +65,7 @@ interface MediaFileAdapterInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception
 	 */
-	public function getFiles($path = '/', $filter = '');
+	public function getFiles($path = DIRECTORY_SEPARATOR, $filter = '');
 
 	/**
 	 * Creates a folder with the given name in the given path.

--- a/administrator/components/com_media/libraries/media/file/adapter/local.php
+++ b/administrator/components/com_media/libraries/media/file/adapter/local.php
@@ -66,10 +66,10 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception
 	 */
-	public function getFile($path = '/')
+	public function getFile($path = DIRECTORY_SEPARATOR)
 	{
 		// Set up the path correctly
-		$path     = JPath::clean('/' . $path);
+		$path     = JPath::clean(DIRECTORY_SEPARATOR . $path);
 		$basePath = JPath::clean($this->rootPath . $path);
 
 		// Check if file exists
@@ -105,10 +105,10 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception
 	 */
-	public function getFiles($path = '/', $filter = '')
+	public function getFiles($path = DIRECTORY_SEPARATOR, $filter = '')
 	{
 		// Set up the path correctly
-		$path     = JPath::clean('/' . $path);
+		$path     = JPath::clean(DIRECTORY_SEPARATOR . $path);
 		$basePath = JPath::clean($this->rootPath . $path);
 
 		// Check if file exists
@@ -129,13 +129,13 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 		// Read the folders
 		foreach (JFolder::folders($basePath, $filter) as $folder)
 		{
-			$data[] = $this->getPathInformation(JPath::clean($basePath . '/' . $folder));
+			$data[] = $this->getPathInformation(JPath::clean($basePath . DIRECTORY_SEPARATOR . $folder));
 		}
 
 		// Read the files
 		foreach (JFolder::files($basePath, $filter) as $file)
 		{
-			$data[] = $this->getPathInformation(JPath::clean($basePath . '/' . $file));
+			$data[] = $this->getPathInformation(JPath::clean($basePath . DIRECTORY_SEPARATOR . $file));
 		}
 
 		// Return the data
@@ -155,7 +155,7 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 	 */
 	public function createFolder($name, $path)
 	{
-		JFolder::create($this->rootPath . $path . '/' . $name);
+		JFolder::create($this->rootPath . $path . DIRECTORY_SEPARATOR . $name);
 	}
 
 	/**
@@ -172,7 +172,7 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 	 */
 	public function createFile($name, $path, $data)
 	{
-		JFile::write($this->rootPath . $path . '/' . $name, $data);
+		JFile::write($this->rootPath . $path . DIRECTORY_SEPARATOR . $name, $data);
 	}
 
 	/**
@@ -189,12 +189,12 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 	 */
 	public function updateFile($name, $path, $data)
 	{
-		if (!JFile::exists($this->rootPath . $path . '/' . $name))
+		if (!JFile::exists($this->rootPath . $path . DIRECTORY_SEPARATOR . $name))
 		{
 			throw new MediaFileAdapterFilenotfoundexception();
 		}
 
-		JFile::write($this->rootPath . $path . '/' . $name, $data);
+		JFile::write($this->rootPath . $path . DIRECTORY_SEPARATOR . $name, $data);
 	}
 
 
@@ -269,7 +269,7 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 		$obj                          = new stdClass;
 		$obj->type                    = $isDir ? 'dir' : 'file';
 		$obj->name                    = basename($path);
-		$obj->path                    = str_replace($this->rootPath, '/', $path);
+		$obj->path                    = str_replace($this->rootPath, DIRECTORY_SEPARATOR, $path);
 		$obj->extension               = !$isDir ? JFile::getExt($obj->name) : '';
 		$obj->size                    = !$isDir ? filesize($path) : 0;
 		$obj->create_date             = $createDate->format('c', true);

--- a/administrator/components/com_media/models/api.php
+++ b/administrator/components/com_media/models/api.php
@@ -39,8 +39,8 @@ class MediaModelApi extends Model
 		if (!isset($config['fileadapter']))
 		{
 			// Compile the root path
-			$root = JPATH_ROOT . '/' . JComponentHelper::getParams('com_media')->get('file_path', 'images');
-			$root = rtrim($root) . '/';
+			$root = JPATH_ROOT . DIRECTORY_SEPARATOR . JComponentHelper::getParams('com_media')->get('file_path', 'images');
+			$root = rtrim($root) . DIRECTORY_SEPARATOR;
 
 			// Default to the local adapter
 			$config['fileadapter'] = new MediaFileAdapterLocal($root);
@@ -61,7 +61,7 @@ class MediaModelApi extends Model
 	 * @throws  Exception
 	 * @see     MediaFileAdapterInterface::getFile()
 	 */
-	public function getFile($path = '/')
+	public function getFile($path = DIRECTORY_SEPARATOR)
 	{
 		return $this->adapter->getFile($path);
 	}
@@ -79,7 +79,7 @@ class MediaModelApi extends Model
 	 * @throws  Exception
 	 * @see     MediaFileAdapterInterface::getFile()
 	 */
-	public function getFiles($path = '/', $filter = '')
+	public function getFiles($path = DIRECTORY_SEPARATOR, $filter = '')
 	{
 		return $this->adapter->getFiles($path, $filter);
 	}


### PR DESCRIPTION
Pull Request for Issue #121.

Uses the OS directory path separator instead of /.