### PR TITLE
Handled error code showing in developer console

### DIFF
--- a/administrator/components/com_media/models/api.php
+++ b/administrator/components/com_media/models/api.php
@@ -56,7 +56,9 @@ class MediaModelApi extends Model
 		}
 
 		if (isset($config['fileadapter']))
+        {
             $this->adapter = $config['fileadapter'];
+        }
 	}
 
 	/**
@@ -92,7 +94,9 @@ class MediaModelApi extends Model
 	public function getFiles($path = '/', $filter = '')
 	{
 	    if (!$this->adapter)
-	        return array();
+        {
+            return array();
+        }
 
 		return $this->adapter->getFiles($path, $filter);
 	}

--- a/administrator/components/com_media/models/api.php
+++ b/administrator/components/com_media/models/api.php
@@ -56,9 +56,9 @@ class MediaModelApi extends Model
 		}
 
 		if (isset($config['fileadapter']))
-        {
-            $this->adapter = $config['fileadapter'];
-        }
+		{
+			$this->adapter = $config['fileadapter'];
+		}
 	}
 
 	/**
@@ -93,10 +93,10 @@ class MediaModelApi extends Model
 	 */
 	public function getFiles($path = '/', $filter = '')
 	{
-	    if (!$this->adapter)
-        {
-            return array();
-        }
+		if (!$this->adapter)
+		{
+			return array();
+		}
 
 		return $this->adapter->getFiles($path, $filter);
 	}

--- a/administrator/components/com_media/models/api.php
+++ b/administrator/components/com_media/models/api.php
@@ -55,7 +55,8 @@ class MediaModelApi extends Model
 			}
 		}
 
-		$this->adapter = $config['fileadapter'];
+		if (isset($config['fileadapter']))
+            $this->adapter = $config['fileadapter'];
 	}
 
 	/**
@@ -90,6 +91,9 @@ class MediaModelApi extends Model
 	 */
 	public function getFiles($path = '/', $filter = '')
 	{
+	    if (!$this->adapter)
+	        return array();
+
 		return $this->adapter->getFiles($path, $filter);
 	}
 


### PR DESCRIPTION
Pull Request for Issue #196 .

### Summary of Changes
Fixed error code displaying in MM when **FileSystem - Local** plugin deactivated


### Testing Instructions
- Open developer console
- Disable **FileSystemLocal** plugin
- Go to Media Manager


### Expected result
- No error code displayed in the Developer Console


### Actual result



### Documentation Changes Required

