### PR TITLE
The root information should be compiled in the local plugin

### DIFF
--- a/administrator/components/com_media/models/api.php
+++ b/administrator/components/com_media/models/api.php
@@ -38,16 +38,12 @@ class MediaModelApi extends Model
 
 		if (!isset($config['fileadapter']))
 		{
-			// Compile the root path
-			$root = JPATH_ROOT . '/' . JComponentHelper::getParams('com_media')->get('file_path', 'images');
-			$root = rtrim($root) . '/';
-
 			// Import Local file system plugin
 			JPluginHelper::importPlugin('filesystem');
 
 			$app = JFactory::getApplication();
 
-			$results = $app->triggerEvent('onFileSystemGetAdapters', array($root));
+			$results = $app->triggerEvent('onFileSystemGetAdapters');
 
 			if ($results != null)
 			{

--- a/plugins/filesystem/local/local.php
+++ b/plugins/filesystem/local/local.php
@@ -32,14 +32,16 @@ class PlgFileSystemLocal extends JPlugin
 	/**
 	 * Returns a local media adapter to the caller which can be used to manipulate files
 	 *
-	 * @param   string  $path  The path used to be initialize a MediaFileAdapter
-	 *
 	 * @return   MediaFileAdapterLocal return a new MediaFileAdapterLocal
 	 *
 	 * @since    version  __DEPLOY_VERSION__
 	 */
-	public function onFileSystemGetAdapters($path)
+	public function onFileSystemGetAdapters()
 	{
-		return new MediaFileAdapterLocal($path);
+		// Compile the root path
+		$root = JPATH_ROOT . '/' . JComponentHelper::getParams('com_media')->get('file_path', 'images');
+		$root = rtrim($root) . '/';
+
+		return new MediaFileAdapterLocal($root);
 	}
 }

--- a/tests/unit/suites/plugins/filesystem/local/PlgFileSystemLocalTest.php
+++ b/tests/unit/suites/plugins/filesystem/local/PlgFileSystemLocalTest.php
@@ -86,7 +86,7 @@ class PlgFileSystemLocalTest extends TestCaseDatabase
 	 */
 	public function testOnFileSystemGetAdapters()
 	{
-		$adapter = $this->pluginClass->onFileSystemGetAdapters($this->root);
+		$adapter = $this->pluginClass->onFileSystemGetAdapters();
 		self::assertInstanceOf('MediaFileAdapterLocal', $adapter);
 	}
 }


### PR DESCRIPTION
The local root path should be compiled in the plugin and not the model as the model doesn't know if the adapter is working on a local fileysystem or a cloud.