### PR TITLE
Remove spaces from upload filenames

### DIFF
--- a/libraries/src/CMS/Helper/MediaHelper.php
+++ b/libraries/src/CMS/Helper/MediaHelper.php
@@ -152,6 +152,7 @@ class MediaHelper
 
 			return false;
 		}
+		$file['name'] = str_replace(' ', '', $file['name']);
 
 		jimport('joomla.filesystem.file');
 


### PR DESCRIPTION
Pull Request for Issue #230 .

### Summary of Changes

when an uploaded file has spaces we remove the space.

### Testing Instructions

try to upload several files with different special characters like spaces, dashes etc.   

### Expected result

Uploaded file and no 403 error

### Actual result



### Documentation Changes Required

