### PR TITLE
Update Model/Api.php Controller/Api.php

### DIFF
--- a/administrator/components/com_media/Controller/Api.php
+++ b/administrator/components/com_media/Controller/Api.php
@@ -246,7 +246,7 @@ class Api extends Controller
 			throw new \Exception(\JText::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'));
 		}
 
-		$name = $this->getSafeName( $name );
+		$name = $this->getSafeName($name);
 		if (!$helper->canUpload(array('name' => $name, 'size' => count($mediaContent), 'tmp_name' => $tmpFile), 'com_media'))
 		{
 			\JFile::delete($tmpFile);

--- a/administrator/components/com_media/Controller/Api.php
+++ b/administrator/components/com_media/Controller/Api.php
@@ -116,6 +116,7 @@ class Api extends Controller
 					$name         = $content->getString('name');
 					$mediaContent = base64_decode($content->get('content', '', 'raw'));
 
+					$name = $this->getSafeName($name);
 					if ($mediaContent)
 					{
 						$this->checkContent($name, $mediaContent);
@@ -245,6 +246,7 @@ class Api extends Controller
 			throw new \Exception(\JText::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'));
 		}
 
+		$name = $this->getSafeName( $name );
 		if (!$helper->canUpload(array('name' => $name, 'size' => count($mediaContent), 'tmp_name' => $tmpFile), 'com_media'))
 		{
 			\JFile::delete($tmpFile);
@@ -253,5 +255,38 @@ class Api extends Controller
 		}
 
 		\JFile::delete($tmpFile);
+	}
+
+	/**
+	 * Creates a safe file name for the given name.
+	 *
+	 * @param   string  $name  The filename
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception
+	 */
+	private function getSafeName($name)
+	{
+		// Make the filename safe
+		$name = \JFile::makeSafe($name);
+
+		// Transform filename to punycode
+		$name = \JStringPunycode::toPunycode($name);
+
+		$extension = \JFile::getExt($name);
+
+		if ($extension)
+		{
+			$extension = '.' . strtolower($extension);
+		}
+
+		// Transform filename to punycode, then neglect other than non-alphanumeric characters & underscores.
+		// Also transform extension to lowercase.
+		$nameWithoutExtension = substr($name, 0, strlen($name) - strlen($extension));
+		$name = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $nameWithoutExtension) . $extension;
+
+		return $name;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #230 .

Summary of Changes

when an uploaded file has spaces it is replace by a underscore (same way for folder creation).
It was done by:
1. moving 'getSafeName' function from the model Api.php to the controller Api.ph
2. Call 'getSafeName' in the controller API in two places: (a) creation of a file or directory, and (b) uploading a new image
3. remove the call of 'getSafeName' in the model

Testing Instructions

try to upload several files with different special characters like spaces, dashes etc.

Expected result

1. Uploaded file and no 403 error

Actual result

I made some tests in "old Joomla (3.7.2), before my changes and after it and swa the following:

1. filename with english latters and one or more spaces
- "old": an error - "Unable to create folder. Folder name must only contain alphanumeric characters and no spaces."
- J4 before the change - 403
- J4 after the change - all spaces are replaced with '_'

2. file name with special charcter (e.g. Hebrew)
- "old": an error - "Unable to create folder. Folder name must only contain alphanumeric characters and no spaces."
- J4 before the change - nothing happens
- J4 after the change - nothing happens

3. directory name with spaces
- "old": an error - "Unable to create folder. Folder name must only contain alphanumeric characters and no spaces."
- J4 before the change - all spaces are replaced with '_'
- J4 after the change - all spaces are replaced with '_'

4. directory with special charcter (e.g. Hebrew)
- "old": an error - "Unable to create folder. Folder name must only contain alphanumeric characters and no spaces."
- J4 before the change - nothing happens
- J4 after the change - nothing happens

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

