### PR TITLE
Update Model/Api.php Controller/Api.php

### DIFF
--- a/administrator/components/com_media/Model/Api.php
+++ b/administrator/components/com_media/Model/Api.php
@@ -120,8 +120,6 @@ class Api extends Model
 	 */
 	public function createFolder($name, $path)
 	{
-		$name = $this->getSafeName($name);
-
 		$this->adapter->createFolder($name, $path);
 
 		return $name;
@@ -143,8 +141,6 @@ class Api extends Model
 	 */
 	public function createFile($name, $path, $data)
 	{
-		$name = $this->getSafeName($name);
-
 		$this->adapter->createFile($name, $path, $data);
 
 		return $name;
@@ -184,39 +180,6 @@ class Api extends Model
 	public function delete($path)
 	{
 		$this->adapter->delete($path);
-	}
-
-	/**
-	 * Creates a safe file name for the given name.
-	 *
-	 * @param   string  $name  The filename
-	 *
-	 * @return  string
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 * @throws  \Exception
-	 */
-	private function getSafeName($name)
-	{
-		// Make the filename safe
-		$name = \JFile::makeSafe($name);
-
-		// Transform filename to punycode
-		$name = \JStringPunycode::toPunycode($name);
-
-		$extension = \JFile::getExt($name);
-
-		if ($extension)
-		{
-			$extension = '.' . strtolower($extension);
-		}
-
-		// Transform filename to punycode, then neglect other than non-alphanumeric characters & underscores.
-		// Also transform extension to lowercase.
-		$nameWithoutExtension = substr($name, 0, strlen($name) - strlen($extension));
-		$name = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $nameWithoutExtension) . $extension;
-
-		return $name;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #230 .

Summary of Changes

when an uploaded file has spaces it is replace by a underscore (same way for folder creation).
It was done by:

moving 'getSafeName' function from the model Api.php to the controller Api.ph
Call 'getSafeName' in the controller API in two places: (a) creation of a file or directory, and (b) uploading a new image
remove the call of 'getSafeName' in the model
Testing Instructions

try to upload several files with different special characters like spaces, dashes etc.

Expected result

Uploaded file and no 403 error
Actual result

I made some tests in "old Joomla (3.7.2), before my changes and after it and swa the following:

filename with english latters and one or more spaces
"old": an error - "Unable to create folder. Folder name must only contain alphanumeric characters and no spaces."
J4 before the change - 403
J4 after the change - all spaces are replaced with '_'
file name with special charcter (e.g. Hebrew)
"old": an error - "Unable to create folder. Folder name must only contain alphanumeric characters and no spaces."
J4 before the change - nothing happens
J4 after the change - nothing happens
directory name with spaces
"old": an error - "Unable to create folder. Folder name must only contain alphanumeric characters and no spaces."
J4 before the change - all spaces are replaced with '_'
J4 after the change - all spaces are replaced with '_'
directory with special charcter (e.g. Hebrew)
"old": an error - "Unable to create folder. Folder name must only contain alphanumeric characters and no spaces."
J4 before the change - nothing happens
J4 after the change - nothing happens
