### PR TITLE
removed name variable from controller when create a file or folder

### DIFF
--- a/administrator/components/com_media/Controller/Api.php
+++ b/administrator/components/com_media/Controller/Api.php
@@ -129,12 +129,12 @@ class Api extends Controller
 						$this->checkContent($name, $mediaContent);
 
 						// A file needs to be created
-						$name = $this->getModel()->createFile($adapter, $name, $path, $mediaContent);
+						$this->getModel()->createFile($adapter, $name, $path, $mediaContent);
 					}
 					else
 					{
 						// A file needs to be created
-						$name = $this->getModel()->createFolder($adapter, $name, $path);
+						$this->getModel()->createFolder($adapter, $name, $path);
 					}
 
 					$data = $this->getModel()->getFile($adapter, $path . '/' . $name);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In Controller there was setting name after createFile or createFolder.
This is not required as we do not return anything from those methods.
Need to remove them to prevent making name null


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

