### PR TITLE
Used directory separator for thumbnail path in Local Adapter

### DIFF
--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -570,7 +570,7 @@ class LocalAdapter implements AdapterInterface
 	 */
 	public function getUrl($path)
 	{
-		return Uri::root() . \JPath::clean($this->filePath . $path);
+		return Uri::root() . \JPath::clean($this->filePath . $path, '/');
 	}
 
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Used directory separator for thumbnail url to work media manager in the Windows environment 


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

