### PR TITLE
Show drive name instead of drive id

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
+++ b/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
@@ -13,7 +13,20 @@
             /* Get the crumbs from the current directory path */
             crumbs () {
                 const items = [];
-                this.$store.state.selectedDirectory.split('/')
+
+                const parts = this.$store.state.selectedDirectory.split('/');
+
+                // Add the drive as first element
+                if (parts) {
+                	const drive = this.findDrive(parts[0]);
+
+                	if (drive) {
+		                items.push(drive);
+		                parts.shift();
+                    }
+                }
+
+                parts
                     .filter(crumb => crumb.length !== 0)
                     .forEach(crumb => {
                         items.push({
@@ -37,6 +50,19 @@
                 }
                 this.$store.dispatch('getContents', path);
             },
+            findDrive: function(adapter) {
+            	let driveObject = null;
+
+	            this.$store.state.disks.forEach(disk => {
+		            disk.drives.forEach(drive => {
+			            if (drive.root.startsWith(adapter)) {
+				            driveObject = {name: drive.displayName, path: drive.root};
+			            }
+		            });
+	            });
+
+	            return driveObject;
+            }
         },
     }
 </script>

--- a/media/com_media/js/mediamanager.js
+++ b/media/com_media/js/mediamanager.js
@@ -17465,7 +17465,19 @@ exports.default = {
             var _this = this;
 
             var items = [];
-            this.$store.state.selectedDirectory.split('/').filter(function (crumb) {
+
+            var parts = this.$store.state.selectedDirectory.split('/');
+
+            if (parts) {
+                var drive = this.findDrive(parts[0]);
+
+                if (drive) {
+                    items.push(drive);
+                    parts.shift();
+                }
+            }
+
+            parts.filter(function (crumb) {
                 return crumb.length !== 0;
             }).forEach(function (crumb) {
                 items.push({
@@ -17486,6 +17498,19 @@ exports.default = {
                 path += '/';
             }
             this.$store.dispatch('getContents', path);
+        },
+        findDrive: function findDrive(adapter) {
+            var driveObject = null;
+
+            this.$store.state.disks.forEach(function (disk) {
+                disk.drives.forEach(function (drive) {
+                    if (drive.root.startsWith(adapter)) {
+                        driveObject = { name: drive.displayName, path: drive.root };
+                    }
+                });
+            });
+
+            return driveObject;
         }
     }
 };


### PR DESCRIPTION
The first item in the breadcrumb shows the adapter id instead of the display name.

Before patch
![image](https://user-images.githubusercontent.com/251072/30697890-ae8909ec-9ee0-11e7-8fef-d548b4cfbf89.png)


After patch
![image](https://user-images.githubusercontent.com/251072/30697821-7e47cb74-9ee0-11e7-8a55-76d6ca3a4f66.png)
