### PR TITLE
Remove the clean function for browser paths

### DIFF
--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -573,7 +573,7 @@ class LocalAdapter implements AdapterInterface
 	 */
 	public function getUrl($path)
 	{
-		return Uri::root() . \JPath::clean($this->getEncodedPath($this->filePath . $path));
+		return Uri::root() . $this->getEncodedPath($this->filePath . $path);
 	}
 
 	/**


### PR DESCRIPTION
On windows are the thumbs not shown in mm.