### PR TITLE
Only work with file extensions which are allowed

### DIFF
--- a/administrator/components/com_media/Controller/ApiController.php
+++ b/administrator/components/com_media/Controller/ApiController.php
@@ -17,8 +17,8 @@ use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Helper\MediaHelper;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Session\Session;
-use Joomla\Component\Media\Administrator\Adapter\FileExistsException;
-use Joomla\Component\Media\Administrator\Adapter\FileNotFoundException;
+use Joomla\Component\Media\Administrator\Exception\FileExistsException;
+use Joomla\Component\Media\Administrator\Exception\FileNotFoundException;
 
 \JLoader::import('joomla.filesystem.file');
 

--- a/administrator/components/com_media/Exception/FileExistsException.php
+++ b/administrator/components/com_media/Exception/FileExistsException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Media\Administrator\Exception;
+
+defined('_JEXEC') or die;
+
+/**
+ * Media file exists exception.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class FileExistsException extends \Exception
+{
+}

--- a/administrator/components/com_media/Exception/FileNotFoundException.php
+++ b/administrator/components/com_media/Exception/FileNotFoundException.php
@@ -7,15 +7,15 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\Component\Media\Administrator\Adapter;
+namespace Joomla\Component\Media\Administrator\Exception;
 
 defined('_JEXEC') or die;
 
 /**
- * Media file adapter file exists exception.
+ * Media file not found exception.
  *
  * @since  __DEPLOY_VERSION__
  */
-class FileExistsException extends \Exception
+class FileNotFoundException extends \Exception
 {
 }

--- a/administrator/components/com_media/Exception/InvalidPathException.php
+++ b/administrator/components/com_media/Exception/InvalidPathException.php
@@ -7,15 +7,15 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\Component\Media\Administrator\Adapter;
+namespace Joomla\Component\Media\Administrator\Exception;
 
 defined('_JEXEC') or die;
 
 /**
- * Media file adapter file not found exception.
+ * Media invalid path exception.
  *
  * @since  __DEPLOY_VERSION__
  */
-class FileNotFoundException extends \Exception
+class InvalidPathException extends \Exception
 {
 }

--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -143,15 +143,17 @@ class ApiModel extends BaseModel
 		}
 
 		// Add adapter prefix to all the files to be returned
-		foreach ($files as $file)
+		foreach ($files as $key => $file)
 		{
+			// Check if the file is valid
 			if ($file->type == 'file' && !$this->isMediaFile($file->path))
 			{
+				// Remove the file from the data
+				unset($files[$key]);
 				continue;
 			}
 
-			// If requested add options
-			// Url can be provided for a file
+			// Check if we need more information
 			if (isset($options['url']) && $options['url'] && $file->type == 'file')
 			{
 				if (isset($options['temp']) && $options['temp'])
@@ -168,7 +170,8 @@ class ApiModel extends BaseModel
 			$file->adapter = $adapter;
 		}
 
-		return $files;
+		// Return array with proper indexes
+		return array_values($files);
 	}
 
 	/**

--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -412,21 +412,29 @@ class ApiModel extends BaseModel
 	 */
 	private function isMediaFile($path)
 	{
+		// Check if there is an extension available
 		if (!strrpos($path, '.'))
 		{
 			return false;
 		}
 
+		// Initialize the allowed extensions
 		if ($this->allowedExtensions === null) {
+
+			// Get the setting from the params
 			$this->allowedExtensions = ComponentHelper::getParams('com_media')->get(
 				'upload_extensions',
 				'bmp,csv,doc,gif,ico,jpg,jpeg,odg,odp,ods,odt,pdf,png,ppt,txt,xcf,xls,BMP,CSV,DOC,GIF,ICO,JPG,JPEG,ODG,ODP,ODS,ODT,PDF,PNG,PPT,TXT,XCF,XLS'
 			);
 
+			// Make them an array
 			$this->allowedExtensions = explode(',', $this->allowedExtensions);
 		}
 
+		// Extract the extension
 		$extension = substr($path, strrpos($path, '.') + 1);
+
+		// Check if the extension exists in the allowed extensions
 		return in_array($extension, $this->allowedExtensions);
 	}
 }

--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -11,12 +11,14 @@ namespace Joomla\Component\Media\Administrator\Model;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\BaseModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Media\Administrator\Adapter\AdapterInterface;
-use Joomla\Component\Media\Administrator\Adapter\FileExistsException;
-use Joomla\Component\Media\Administrator\Adapter\FileNotFoundException;
+use Joomla\Component\Media\Administrator\Exception\FileExistsException;
+use Joomla\Component\Media\Administrator\Exception\FileNotFoundException;
+use Joomla\Component\Media\Administrator\Exception\InvalidPathException;
 use Joomla\Component\Media\Administrator\Event\MediaProviderEvent;
 use Joomla\Component\Media\Administrator\Provider\ProviderManager;
 
@@ -34,6 +36,14 @@ class ApiModel extends BaseModel
 	 * @since  __DEPLOY_VERSION__
 	 */
 	private $providerManager = null;
+
+	/**
+	 * The available extensions.
+	 *
+	 * @var   string[]
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $allowedExtensions = null;
 
 	/**
 	 * Return the requested adapter
@@ -80,6 +90,12 @@ class ApiModel extends BaseModel
 		// Add adapter prefix to the file returned
 		$file = $this->getAdapter($adapter)->getFile($path);
 
+		// Check if it is a media file
+		if ($file->type == 'file' && !$this->isMediaFile($file->path))
+		{
+			throw new InvalidPathException;
+		}
+
 		if (isset($options['url']) && $options['url'] && $file->type == 'file')
 		{
 			if (isset($options['temp']) && $options['temp'])
@@ -118,7 +134,7 @@ class ApiModel extends BaseModel
 		if ($options['search'] != null)
 		{
 			// Do search
-			$files = $this->search($adapter, $path, $options['search'], $options['recursive']);
+			$files = $this->search($adapter, $options['search'], $path, $options['recursive']);
 		}
 		else
 		{
@@ -129,6 +145,11 @@ class ApiModel extends BaseModel
 		// Add adapter prefix to all the files to be returned
 		foreach ($files as $file)
 		{
+			if ($file->type == 'file' && !$this->isMediaFile($file->path))
+			{
+				continue;
+			}
+
 			// If requested add options
 			// Url can be provided for a file
 			if (isset($options['url']) && $options['url'] && $file->type == 'file')
@@ -214,6 +235,12 @@ class ApiModel extends BaseModel
 			throw new FileExistsException;
 		}
 
+		// Check if it is a media file
+		if (!$this->isMediaFile($path . '/' . $name))
+		{
+			throw new InvalidPathException;
+		}
+
 		$this->getAdapter($adapter)->createFile($name, $path, $data);
 	}
 
@@ -234,6 +261,12 @@ class ApiModel extends BaseModel
 	 */
 	public function updateFile($adapter, $name, $path, $data)
 	{
+		// Check if it is a media file
+		if (!$this->isMediaFile($path . '/' . $name))
+		{
+			throw new InvalidPathException;
+		}
+
 		$this->getAdapter($adapter)->updateFile($name, $path, $data);
 	}
 
@@ -252,6 +285,14 @@ class ApiModel extends BaseModel
 	 */
 	public function delete($adapter, $path)
 	{
+		$file = $this->getFile($adapter, $path);
+
+		// Check if it is a media file
+		if ($file->type == 'file' && !$this->isMediaFile($file->path))
+		{
+			throw new InvalidPathException;
+		}
+
 		$this->getAdapter($adapter)->delete($path);
 	}
 
@@ -307,6 +348,12 @@ class ApiModel extends BaseModel
 	 */
 	public function getUrl($adapter, $path)
 	{
+		// Check if it is a media file
+		if (!$this->isMediaFile($path))
+		{
+			throw new InvalidPathException;
+		}
+
 		return $this->getAdapter($adapter)->getUrl($path);
 	}
 
@@ -314,15 +361,16 @@ class ApiModel extends BaseModel
 	 * Search for a pattern in a given path
 	 *
 	 * @param   string  $adapter    The adapter to work on
+	 * @param   string  $needle     The search therm
 	 * @param   string  $path       The base path for the search
-	 * @param   string  $needle     The path to file
 	 * @param   bool    $recursive  Do a recursive search
 	 *
 	 * @return \stdClass[]
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws \Exception
 	 */
-	public function search($adapter, $path = '/', $needle, $recursive = true)
+	public function search($adapter, $needle, $path = '/', $recursive = true)
 	{
 		return $this->getAdapter($adapter)->search($path, $needle, $recursive);
 	}
@@ -337,10 +385,45 @@ class ApiModel extends BaseModel
 	 * @return string
 	 *
 	 * @since   __DEPLOY_VERSION__
-	 * @throws \FileNotFoundException
+	 * @throws \Exception
 	 */
 	public function getTemporaryUrl($adapter, $path)
 	{
+		// Check if it is a media file
+		if (!$this->isMediaFile($path))
+		{
+			throw new InvalidPathException;
+		}
+
 		return $this->getAdapter($adapter)->getTemporaryUrl($path);
+	}
+
+	/**
+	 * Checks if the given path is an allowed media file.
+	 *
+	 * @param   string  $path  The path to file
+	 *
+	 * @return boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function isMediaFile($path)
+	{
+		if (!strrpos($path, '.'))
+		{
+			return false;
+		}
+
+		if ($this->allowedExtensions === null) {
+			$this->allowedExtensions = ComponentHelper::getParams('com_media')->get(
+				'upload_extensions',
+				'bmp,csv,doc,gif,ico,jpg,jpeg,odg,odp,ods,odt,pdf,png,ppt,txt,xcf,xls,BMP,CSV,DOC,GIF,ICO,JPG,JPEG,ODG,ODP,ODS,ODT,PDF,PNG,PPT,TXT,XCF,XLS'
+			);
+
+			$this->allowedExtensions = explode(',', $this->allowedExtensions);
+		}
+
+		$extension = substr($path, strrpos($path, '.') + 1);
+		return in_array($extension, $this->allowedExtensions);
 	}
 }

--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\MediaHelper;
 use Joomla\Component\Media\Administrator\Adapter\AdapterInterface;
-use Joomla\Component\Media\Administrator\Adapter\FileNotFoundException;
+use Joomla\Component\Media\Administrator\Exception\FileNotFoundException;
 use Joomla\Image\Image;
 use Joomla\CMS\Uri\Uri;
 


### PR DESCRIPTION
Pull Request for Issue #416.

### Summary of Changes
The media manager should only work with files which are allowed file extensions in the settings.
![image](https://user-images.githubusercontent.com/251072/31008900-ee174512-a505-11e7-8f2e-614f336f7fa5.png)

### Testing Instructions
Put a PHP or JS file in the images folder.

### Expected result
The none media files should not being displayed.

### Actual result
All files are displayed.