### PR TITLE
Fix "Undefined variable: file" error

### DIFF
--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -233,7 +233,7 @@ class ApiModel extends BaseModel
 		{}
 
 		// Check if the file exists
-		if ($file && !$override)
+		if (isset($file) && !$override)
 		{
 			throw new FileExistsException;
 		}


### PR DESCRIPTION
When uploading a file a "Undefined variable: file" error is thrown in the api model.