### PR TITLE
 Adapter is responsible for filename normalization

### DIFF
--- a/administrator/components/com_media/Adapter/AdapterInterface.php
+++ b/administrator/components/com_media/Adapter/AdapterInterface.php
@@ -72,7 +72,7 @@ interface AdapterInterface
 	 * Creates a folder with the given name in the given path.
 	 *
 	 * It returns the new folder name. This allows the implementation
-	 * classes to normalize the file name.
+	 * classes to normalise the file name.
 	 *
 	 * @param   string  $name  The name
 	 * @param   string  $path  The folder
@@ -88,7 +88,7 @@ interface AdapterInterface
 	 * Creates a file with the given name in the given path with the data.
 	 *
 	 * It returns the new file name. This allows the implementation
-	 * classes to normalize the file name.
+	 * classes to normalise the file name.
 	 *
 	 * @param   string  $name  The name
 	 * @param   string  $path  The folder
@@ -131,7 +131,7 @@ interface AdapterInterface
 	 * Moves a file or folder from source to destination.
 	 *
 	 * It returns the new destination path. This allows the implementation
-	 * classes to normalize the file name.
+	 * classes to normalise the file name.
 	 *
 	 * @param   string  $sourcePath       The source path
 	 * @param   string  $destinationPath  The destination path
@@ -148,7 +148,7 @@ interface AdapterInterface
 	 * Copies a file or folder from source to destination.
 	 *
 	 * It returns the new destination path. This allows the implementation
-	 * classes to normalize the file name.
+	 * classes to normalise the file name.
 	 *
 	 * @param   string  $sourcePath       The source path
 	 * @param   string  $destinationPath  The destination path

--- a/administrator/components/com_media/Adapter/AdapterInterface.php
+++ b/administrator/components/com_media/Adapter/AdapterInterface.php
@@ -71,10 +71,13 @@ interface AdapterInterface
 	/**
 	 * Creates a folder with the given name in the given path.
 	 *
+	 * It returns the new folder name. This allows the implementation
+	 * classes to normalize the file name.
+	 *
 	 * @param   string  $name  The name
 	 * @param   string  $path  The folder
 	 *
-	 * @return  void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
@@ -84,11 +87,14 @@ interface AdapterInterface
 	/**
 	 * Creates a file with the given name in the given path with the data.
 	 *
+	 * It returns the new file name. This allows the implementation
+	 * classes to normalize the file name.
+	 *
 	 * @param   string  $name  The name
 	 * @param   string  $path  The folder
 	 * @param   binary  $data  The data
 	 *
-	 * @return  void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
@@ -122,13 +128,16 @@ interface AdapterInterface
 	public function delete($path);
 
 	/**
-	 * Moves a file or folder from source to destination
+	 * Moves a file or folder from source to destination.
+	 *
+	 * It returns the new destination path. This allows the implementation
+	 * classes to normalize the file name.
 	 *
 	 * @param   string  $sourcePath       The source path
 	 * @param   string  $destinationPath  The destination path
 	 * @param   bool    $force            Force to overwrite
 	 *
-	 * @return void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
@@ -136,13 +145,16 @@ interface AdapterInterface
 	public function move($sourcePath, $destinationPath, $force = false);
 
 	/**
-	 * Copies a file or folder from source to destination
+	 * Copies a file or folder from source to destination.
+	 *
+	 * It returns the new destination path. This allows the implementation
+	 * classes to normalize the file name.
 	 *
 	 * @param   string  $sourcePath       The source path
 	 * @param   string  $destinationPath  The destination path
 	 * @param   bool    $force            Force to overwrite
 	 *
-	 * @return void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception

--- a/administrator/components/com_media/Controller/ApiController.php
+++ b/administrator/components/com_media/Controller/ApiController.php
@@ -194,19 +194,17 @@ class ApiController extends BaseController
 		$mediaContent = base64_decode($content->get('content', '', 'raw'));
 		$override     = $content->get('override', false);
 
-		$name = $this->getSafeName($name);
-
 		if ($mediaContent)
 		{
-			$this->checkContent($name, $mediaContent);
+			$this->checkContent();
 
 			// A file needs to be created
-			$this->getModel()->createFile($adapter, $name, $path, $mediaContent, $override);
+			$name = $this->getModel()->createFile($adapter, $name, $path, $mediaContent, $override);
 		}
 		else
 		{
 			// A file needs to be created
-			$this->getModel()->createFolder($adapter, $name, $path, $override);
+			$name = $this->getModel()->createFolder($adapter, $name, $path, $override);
 		}
 
 		return $this->getModel()->getFile($adapter, $path . '/' . $name);
@@ -266,7 +264,7 @@ class ApiController extends BaseController
 
 		if ($mediaContent != null)
 		{
-			$this->checkContent($name, $mediaContent);
+			$this->checkContent();
 
 			$this->getModel()->updateFile($adapter, $name, str_replace($name, '', $path), $mediaContent);
 		}
@@ -277,11 +275,11 @@ class ApiController extends BaseController
 
 			if ($move)
 			{
-				$this->getModel()->move($adapter, $path, $destinationPath, true);
+				$destinationPath = $this->getModel()->move($adapter, $path, $destinationPath, true);
 			}
 			else
 			{
-				$this->getModel()->copy($adapter, $path, $destinationPath, true);
+				$destinationPath = $this->getModel()->copy($adapter, $path, $destinationPath, true);
 			}
 
 			$path = $destinationPath;
@@ -333,17 +331,14 @@ class ApiController extends BaseController
 	}
 
 	/**
-	 * Performs various check if it is allowed to save the content with the given name.
-	 *
-	 * @param   string  $name          The filename
-	 * @param   string  $mediaContent  The media content
+	 * Performs various check if it is allowed to save the content.
 	 *
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
-	private function checkContent($name, $mediaContent)
+	private function checkContent()
 	{
 		if (!Factory::getUser()->authorise('core.create', 'com_media'))
 		{
@@ -352,7 +347,7 @@ class ApiController extends BaseController
 
 		$params = ComponentHelper::getParams('com_media');
 
-		$helper = new MediaHelper;
+		$helper       = new MediaHelper;
 		$serverlength = $this->input->server->get('CONTENT_LENGTH');
 
 		if ($serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024)
@@ -362,57 +357,6 @@ class ApiController extends BaseController
 		{
 			throw new \Exception(\JText::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'), 403);
 		}
-
-		// @todo find a better way to check the input, by not writing the file to the disk
-		$tmpFile = $this->app->getConfig()->get('tmp_path') . '/' . uniqid() . $name;
-
-		if (!\JFile::write($tmpFile, $mediaContent))
-		{
-			throw new \Exception(\JText::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'), 500);
-		}
-
-		$name = $this->getSafeName($name);
-		if (!$helper->canUpload(array('name' => $name, 'size' => count($mediaContent), 'tmp_name' => $tmpFile), 'com_media'))
-		{
-			\JFile::delete($tmpFile);
-
-			throw new \Exception(\JText::_('COM_MEDIA_ERROR_UNABLE_TO_UPLOAD_FILE'), 403);
-		}
-
-		\JFile::delete($tmpFile);
-	}
-
-	/**
-	 * Creates a safe file name for the given name.
-	 *
-	 * @param   string  $name  The filename
-	 *
-	 * @return  string
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 * @throws  \Exception
-	 */
-	private function getSafeName($name)
-	{
-		// Make the filename safe
-		$name = \JFile::makeSafe($name);
-
-		// Transform filename to punycode
-		$name = \JStringPunycode::toPunycode($name);
-
-		$extension = \JFile::getExt($name);
-
-		if ($extension)
-		{
-			$extension = '.' . strtolower($extension);
-		}
-
-		// Transform filename to punycode, then neglect other than non-alphanumeric characters & underscores.
-		// Also transform extension to lowercase.
-		$nameWithoutExtension = substr($name, 0, strlen($name) - strlen($extension));
-		$name = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $nameWithoutExtension) . $extension;
-
-		return $name;
 	}
 
 	/**

--- a/administrator/components/com_media/Controller/ApiController.php
+++ b/administrator/components/com_media/Controller/ApiController.php
@@ -331,7 +331,7 @@ class ApiController extends BaseController
 	}
 
 	/**
-	 * Performs various check if it is allowed to save the content.
+	 * Performs various checks if it is allowed to save the content.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -183,7 +183,7 @@ class ApiModel extends BaseModel
 	 * @param   string   $path      The folder
 	 * @param   boolean  $override  Should the folder being overriden when it exists
 	 *
-	 * @return  void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
@@ -206,7 +206,7 @@ class ApiModel extends BaseModel
 			throw new FileExistsException;
 		}
 
-		$this->getAdapter($adapter)->createFolder($name, $path);
+		return $this->getAdapter($adapter)->createFolder($name, $path);
 	}
 
 	/**
@@ -219,7 +219,7 @@ class ApiModel extends BaseModel
 	 * @param   binary   $data      The data
 	 * @param   boolean  $override  Should the file being overriden when it exists
 	 *
-	 * @return  void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
@@ -248,7 +248,7 @@ class ApiModel extends BaseModel
 			throw new InvalidPathException;
 		}
 
-		$this->getAdapter($adapter)->createFile($name, $path, $data);
+		return $this->getAdapter($adapter)->createFile($name, $path, $data);
 	}
 
 	/**
@@ -312,14 +312,14 @@ class ApiModel extends BaseModel
 	 * @param   string  $destinationPath  Destination path(relative)
 	 * @param   bool    $force            Force to overwrite
 	 *
-	 * @return void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
 	public function copy($adapter, $sourcePath, $destinationPath, $force = false)
 	{
-		$this->getAdapter($adapter)->copy($sourcePath, $destinationPath, $force);
+		return $this->getAdapter($adapter)->copy($sourcePath, $destinationPath, $force);
 	}
 
 	/**
@@ -331,14 +331,14 @@ class ApiModel extends BaseModel
 	 * @param   string  $destinationPath  Destination path(relative)
 	 * @param   bool    $force            Force to overwrite
 	 *
-	 * @return void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
 	public function move($adapter, $sourcePath, $destinationPath, $force = false)
 	{
-		$this->getAdapter($adapter)->move($sourcePath, $destinationPath, $force);
+		return $this->getAdapter($adapter)->move($sourcePath, $destinationPath, $force);
 	}
 
 	/**
@@ -348,10 +348,10 @@ class ApiModel extends BaseModel
 	 * @param   string  $adapter  The adapter
 	 * @param   string  $path     The relative path for the file
 	 *
-	 * @return string  Permalink to the relative file
+	 * @return  string  Permalink to the relative file
 	 *
 	 * @since   __DEPLOY_VERSION__
-	 * @throws FileNotFoundException
+	 * @throws  FileNotFoundException
 	 */
 	public function getUrl($adapter, $path)
 	{

--- a/administrator/components/com_media/View/File/HtmlView.php
+++ b/administrator/components/com_media/View/File/HtmlView.php
@@ -48,7 +48,7 @@ class HtmlView extends BaseHtmlView
 		$this->file = $this->getModel()->getFileInformation($input->getString('path', null));
 
 		// At the moment we only support local files to edit
-		if (strpos($this->file->adapter, 'local-') !== 0)
+		if (empty($this->file->localpath))
 		{
 			// @todo error handling controller redirect files
 			throw new \Exception('Image file is not locally');

--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -29,8 +29,6 @@ $form = $this->form;
 
 $tmpl = JFactory::getApplication()->input->getCmd('tmpl', '');
 
-$localPath = str_replace(\Joomla\CMS\Uri\Uri::root(), DIRECTORY_SEPARATOR, $this->file->url);
-
 // Populate the media config
 $config = [
 	'apiBaseUrl'              => JUri::root() . 'administrator/index.php?option=com_media&format=json',
@@ -39,7 +37,7 @@ $config = [
 	'editViewUrl'             => JUri::root() . 'administrator/index.php?option=com_media&view=file' . $tmpl,
 	'allowedUploadExtensions' => $params->get('upload_extensions', ''),
 	'maxUploadSizeMb'         => $params->get('upload_maxsize', 10),
-	'contents'                => base64_encode(file_get_contents(JPATH_ROOT . $localPath)),
+	'contents'                => base64_encode(file_get_contents($this->file->localpath)),
 ];
 
 JFactory::getDocument()->addScriptOptions('com_media', $config);

--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -155,7 +155,7 @@ class MediaHelper
 
 		jimport('joomla.filesystem.file');
 
-		if (str_replace(' ', '', $file['name']) !== $file['name'] || $file['name'] !== \JFile::makeSafe($file['name']))
+		if ($file['name'] !== \JFile::makeSafe($file['name']))
 		{
 			$app->enqueueMessage(\JText::_('JLIB_MEDIA_ERROR_WARNFILENAME'), 'error');
 

--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -121,7 +121,7 @@ class MediaHelper
 		if ($params->get('check_mime', 1))
 		{
 			// Get the mime type configuration
-			$allowedMime = array_map('trim', explode(',', $params->get('upload_mime')));
+			$allowedMime = array_map('trim', explode(',', $params->get('upload_mime', 'image/jpeg,image/gif,image/png,image/bmp,application/msword,application/excel,application/pdf,application/powerpoint,text/plain,application/x-zip')));
 
 			// Mime should be available and in the whitelist
 			return !empty($mime) && in_array($mime, $allowedMime);
@@ -190,7 +190,7 @@ class MediaHelper
 		}
 
 		$filetype  = array_pop($filetypes);
-		$allowable = array_map('trim', explode(',', $params->get('upload_extensions')));
+		$allowable = array_map('trim', explode(',', $params->get('upload_extensions', 'bmp,csv,doc,gif,ico,jpg,jpeg,odg,odp,ods,odt,pdf,png,ppt,txt,xcf,xls,BMP,CSV,DOC,GIF,ICO,JPG,JPEG,ODG,ODP,ODS,ODT,PDF,PNG,PPT,TXT,XCF,XLS')));
 		$ignored   = array_map('trim', explode(',', $params->get('ignore_extensions')));
 
 		if ($filetype == '' || $filetype == false || (!in_array($filetype, $allowable) && !in_array($filetype, $ignored)))

--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -746,6 +746,7 @@ class LocalAdapter implements AdapterInterface
 		}
 
 		$nameWithoutExtension = substr($name, 0, strlen($name) - strlen($extension));
+		$nameWithoutExtension = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $nameWithoutExtension);
 
 		return $nameWithoutExtension . $extension;
 	}

--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -204,7 +204,7 @@ class LocalAdapter implements AdapterInterface
 	{
 		$name = $this->getSafeName($name);
 
-		$this->checkContent($name, $data);
+		$this->checkContent($name, $path, $data);
 
 		\JFile::write($this->rootPath . $path . '/' . $name, $data);
 
@@ -230,7 +230,7 @@ class LocalAdapter implements AdapterInterface
 			throw new FileNotFoundException;
 		}
 
-		$this->checkContent($name, $data);
+		$this->checkContent($name, $path, $data);
 
 		\JFile::write($this->rootPath . $path . '/' . $name, $data);
 	}
@@ -402,7 +402,7 @@ class LocalAdapter implements AdapterInterface
 		// If the safe name is different normalize the file name
 		if ($safeName != $name)
 		{
-			$destinationPath = substr($destinationPath, 0, -count($name)) . '/' . $safeName;
+			$destinationPath = substr($destinationPath, 0, -strlen($name)) . '/' . $safeName;
 		}
 
 		// Check for existence of the file in destination
@@ -512,7 +512,7 @@ class LocalAdapter implements AdapterInterface
 		// If the safe name is different normalize the file name
 		if ($safeName != $name)
 		{
-			$destinationPath = substr($destinationPath, 0, -count($name)) . '/' . $safeName;
+			$destinationPath = substr($destinationPath, 0, -strlen($name)) . '/' . $safeName;
 		}
 
 		if (is_dir($sourcePath))
@@ -754,6 +754,7 @@ class LocalAdapter implements AdapterInterface
 	 * Performs various check if it is allowed to save the content with the given name.
 	 *
 	 * @param   string  $name          The filename
+	 * @param   string  $path          The path
 	 * @param   string  $mediaContent  The media content
 	 *
 	 * @return  void
@@ -761,13 +762,13 @@ class LocalAdapter implements AdapterInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
-	private function checkContent($name, $mediaContent)
+	private function checkContent($name, $path, $mediaContent)
 	{
 		// The helper
 		$helper = new MediaHelper;
 
 		// @todo find a better way to check the input, by not writing the file to the disk
-		$tmpFile = Factory::getApplication()->getConfig()->get('tmp_path') . '/' . uniqid() . '.' . \JFile::getExt($name);
+		$tmpFile = \JPath::clean($this->rootPath . '/' . $path . '/' . uniqid() . '.' . \JFile::getExt($name));
 
 		if (!\JFile::write($tmpFile, $mediaContent))
 		{

--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -166,7 +166,7 @@ class LocalAdapter implements AdapterInterface
 	 * Creates a folder with the given name in the given path.
 	 *
 	 * It returns the new folder name. This allows the implementation
-	 * classes to normalize the file name.
+	 * classes to normalise the file name.
 	 *
 	 * @param   string  $name  The name
 	 * @param   string  $path  The folder
@@ -189,7 +189,7 @@ class LocalAdapter implements AdapterInterface
 	 * Creates a file with the given name in the given path with the data.
 	 *
 	 * It returns the new file name. This allows the implementation
-	 * classes to normalize the file name.
+	 * classes to normalise the file name.
 	 *
 	 * @param   string  $name  The name
 	 * @param   string  $path  The folder
@@ -374,7 +374,7 @@ class LocalAdapter implements AdapterInterface
 	 * Copies a file or folder from source to destination.
 	 *
 	 * It returns the new destination path. This allows the implementation
-	 * classes to normalize the file name.
+	 * classes to normalise the file name.
 	 *
 	 * @param   string  $sourcePath       The source path
 	 * @param   string  $destinationPath  The destination path
@@ -399,7 +399,7 @@ class LocalAdapter implements AdapterInterface
 		$name     = basename($destinationPath);
 		$safeName = $this->getSafeName($name);
 
-		// If the safe name is different normalize the file name
+		// If the safe name is different normalise the file name
 		if ($safeName != $name)
 		{
 			$destinationPath = substr($destinationPath, 0, -strlen($name)) . '/' . $safeName;
@@ -484,7 +484,7 @@ class LocalAdapter implements AdapterInterface
 	 * Moves a file or folder from source to destination.
 	 *
 	 * It returns the new destination path. This allows the implementation
-	 * classes to normalize the file name.
+	 * classes to normalise the file name.
 	 *
 	 * @param   string  $sourcePath       The source path
 	 * @param   string  $destinationPath  The destination path
@@ -509,7 +509,7 @@ class LocalAdapter implements AdapterInterface
 		$name     = basename($destinationPath);
 		$safeName = $this->getSafeName($name);
 
-		// If the safe name is different normalize the file name
+		// If the safe name is different normalise the file name
 		if ($safeName != $name)
 		{
 			$destinationPath = substr($destinationPath, 0, -strlen($name)) . '/' . $safeName;

--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -11,7 +11,9 @@ namespace Joomla\Plugin\Filesystem\Local\Adapter;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\MediaHelper;
+use Joomla\CMS\String\PunycodeHelper;
 use Joomla\Component\Media\Administrator\Adapter\AdapterInterface;
 use Joomla\Component\Media\Administrator\Exception\FileNotFoundException;
 use Joomla\Image\Image;
@@ -163,34 +165,50 @@ class LocalAdapter implements AdapterInterface
 	/**
 	 * Creates a folder with the given name in the given path.
 	 *
+	 * It returns the new folder name. This allows the implementation
+	 * classes to normalize the file name.
+	 *
 	 * @param   string  $name  The name
 	 * @param   string  $path  The folder
 	 *
-	 * @return  void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
 	public function createFolder($name, $path)
 	{
+		$name = $this->getSafeName($name);
+
 		\JFolder::create($this->rootPath . $path . '/' . $name);
+
+		return $name;
 	}
 
 	/**
 	 * Creates a file with the given name in the given path with the data.
 	 *
+	 * It returns the new file name. This allows the implementation
+	 * classes to normalize the file name.
+	 *
 	 * @param   string  $name  The name
 	 * @param   string  $path  The folder
-	 * @param   string  $data  The data
+	 * @param   binary  $data  The data
 	 *
-	 * @return  void
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
 	public function createFile($name, $path, $data)
 	{
+		$name = $this->getSafeName($name);
+
+		$this->checkContent($name, $data);
+
 		\JFile::write($this->rootPath . $path . '/' . $name, $data);
+
+		return $name;
 	}
 
 	/**
@@ -211,6 +229,8 @@ class LocalAdapter implements AdapterInterface
 		{
 			throw new FileNotFoundException;
 		}
+
+		$this->checkContent($name, $data);
 
 		\JFile::write($this->rootPath . $path . '/' . $name, $data);
 	}
@@ -290,6 +310,7 @@ class LocalAdapter implements AdapterInterface
 		$obj->type      = $isDir ? 'dir' : 'file';
 		$obj->name      = basename($path);
 		$obj->path      = str_replace($this->rootPath, '/', $path);
+		$obj->localpath = $path;
 		$obj->extension = !$isDir ? \JFile::getExt($obj->name) : '';
 		$obj->size      = !$isDir ? filesize($path) : 0;
 		$obj->mime_type = MediaHelper::getMimeType($path, MediaHelper::isImage($obj->name));
@@ -350,23 +371,24 @@ class LocalAdapter implements AdapterInterface
 	}
 
 	/**
-	 * Copies a file or folder to a destination
-	 * If the destination folder or file already exists, it will not overwrite them without
-	 * force.
+	 * Copies a file or folder from source to destination.
 	 *
-	 * @param   string  $sourcePath       Source path of the file or directory
-	 * @param   string  $destinationPath  Destination path of the file or directory
-	 * @param   bool    $force            Set true to overwrite files or directories
+	 * It returns the new destination path. This allows the implementation
+	 * classes to normalize the file name.
 	 *
-	 * @return void
+	 * @param   string  $sourcePath       The source path
+	 * @param   string  $destinationPath  The destination path
+	 * @param   bool    $force            Force to overwrite
 	 *
-	 * @since __DEPLOY_VERSION__
-	 * @throws FileNotFoundException
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception
 	 */
 	public function copy($sourcePath, $destinationPath, $force = false)
 	{
 		// Get absolute paths from relative paths
-		$sourcePath = \JPath::clean($this->rootPath . $sourcePath, '/');
+		$sourcePath      = \JPath::clean($this->rootPath . $sourcePath, '/');
 		$destinationPath = \JPath::clean($this->rootPath . $destinationPath, '/');
 
 		if (!file_exists($sourcePath))
@@ -374,9 +396,17 @@ class LocalAdapter implements AdapterInterface
 			throw new FileNotFoundException;
 		}
 
+		$name     = basename($destinationPath);
+		$safeName = $this->getSafeName($name);
+
+		// If the safe name is different normalize the file name
+		if ($safeName != $name)
+		{
+			$destinationPath = substr($destinationPath, 0, -count($name)) . '/' . $safeName;
+		}
+
 		// Check for existence of the file in destination
 		// if it does not exists simply copy source to destination
-
 		if (is_dir($sourcePath))
 		{
 			$this->copyFolder($sourcePath, $destinationPath, $force);
@@ -385,6 +415,8 @@ class LocalAdapter implements AdapterInterface
 		{
 			$this->copyFile($sourcePath, $destinationPath, $force);
 		}
+
+		return $destinationPath;
 	}
 
 	/**
@@ -394,9 +426,9 @@ class LocalAdapter implements AdapterInterface
 	 * @param   string  $destinationPath  Destination path of the file or directory
 	 * @param   bool    $force            Set true to overwrite files or directories
 	 *
-	 * @return void
+	 * @return  void
 	 *
-	 * @since __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
 	private function copyFile($sourcePath, $destinationPath, $force = false)
@@ -425,9 +457,9 @@ class LocalAdapter implements AdapterInterface
 	 * @param   string  $destinationPath  Destination path of the file or directory
 	 * @param   bool    $force            Set true to overwrite files or directories
 	 *
-	 * @return void
+	 * @return  void
 	 *
-	 * @since __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
 	private function copyFolder($sourcePath, $destinationPath, $force = false)
@@ -449,28 +481,38 @@ class LocalAdapter implements AdapterInterface
 	}
 
 	/**
-	 * Moves a file or folder to a destination
-	 * If the destination folder or file already exists, it will not overwrite them without
-	 * force.
+	 * Moves a file or folder from source to destination.
 	 *
-	 * @param   string  $sourcePath       Source path of the file or directory
-	 * @param   string  $destinationPath  Destination path of the file or directory
-	 * @param   bool    $force            Set true to overwrite files or directories
+	 * It returns the new destination path. This allows the implementation
+	 * classes to normalize the file name.
 	 *
-	 * @return void
+	 * @param   string  $sourcePath       The source path
+	 * @param   string  $destinationPath  The destination path
+	 * @param   bool    $force            Force to overwrite
 	 *
-	 * @since __DEPLOY_VERSION__
-	 * @throws FileNotFoundException
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception
 	 */
 	public function move($sourcePath, $destinationPath, $force = false)
 	{
 		// Get absolute paths from relative paths
-		$sourcePath = \JPath::clean($this->rootPath . $sourcePath, '/');
+		$sourcePath      = \JPath::clean($this->rootPath . $sourcePath, '/');
 		$destinationPath = \JPath::clean($this->rootPath . $destinationPath, '/');
 
 		if (!file_exists($sourcePath))
 		{
 			throw new FileNotFoundException;
+		}
+
+		$name     = basename($destinationPath);
+		$safeName = $this->getSafeName($name);
+
+		// If the safe name is different normalize the file name
+		if ($safeName != $name)
+		{
+			$destinationPath = substr($destinationPath, 0, -count($name)) . '/' . $safeName;
 		}
 
 		if (is_dir($sourcePath))
@@ -481,6 +523,8 @@ class LocalAdapter implements AdapterInterface
 		{
 			$this->moveFile($sourcePath, $destinationPath, $force);
 		}
+
+		return $destinationPath;
 	}
 
 	/**
@@ -490,9 +534,9 @@ class LocalAdapter implements AdapterInterface
 	 * @param   string  $destinationPath  Absolute path of destination
 	 * @param   bool    $force            Set true to overwrite file if exists
 	 *
-	 * @return void
+	 * @return  void
 	 *
-	 * @since __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
 	private function moveFile($sourcePath, $destinationPath, $force = false)
@@ -521,9 +565,9 @@ class LocalAdapter implements AdapterInterface
 	 * @param   string  $destinationPath  Destination path of the file or directory
 	 * @param   bool    $force            Set true to overwrite files or directories
 	 *
-	 * @return void
+	 * @return  void
 	 *
-	 * @since __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  \Exception
 	 */
 	private function moveFolder($sourcePath, $destinationPath, $force = false)
@@ -652,7 +696,7 @@ class LocalAdapter implements AdapterInterface
 	 * @return string
 	 *
 	 * @since   __DEPLOY_VERSION__
-	 * @throws \FileNotFoundException
+	 * @throws FileNotFoundException
 	 */
 	public function getTemporaryUrl($path)
 	{
@@ -667,10 +711,76 @@ class LocalAdapter implements AdapterInterface
 	 * @return string
 	 *
 	 * @since   __DEPLOY_VERSION__
-	 * @throws \FileNotFoundException
+	 * @throws FileNotFoundException
 	 */
 	private function getEncodedPath($path)
 	{
 		return str_replace(" ", "%20", $path);
+	}
+
+	/**
+	 * Creates a safe file name for the given name.
+	 *
+	 * @param   string  $name  The filename
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception
+	 */
+	private function getSafeName($name)
+	{
+		// Make the filename safe
+		$name = \JFile::makeSafe($name);
+
+		// Transform filename to punycode
+		$name = PunycodeHelper::toPunycode($name);
+
+		// Get the extension
+		$extension = \JFile::getExt($name);
+
+		// Normalise extension, always lower case
+		if ($extension)
+		{
+			$extension = '.' . strtolower($extension);
+		}
+
+		$nameWithoutExtension = substr($name, 0, strlen($name) - strlen($extension));
+
+		return $nameWithoutExtension . $extension;
+	}
+
+	/**
+	 * Performs various check if it is allowed to save the content with the given name.
+	 *
+	 * @param   string  $name          The filename
+	 * @param   string  $mediaContent  The media content
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception
+	 */
+	private function checkContent($name, $mediaContent)
+	{
+		// The helper
+		$helper = new MediaHelper;
+
+		// @todo find a better way to check the input, by not writing the file to the disk
+		$tmpFile = Factory::getApplication()->getConfig()->get('tmp_path') . '/' . uniqid() . '.' . \JFile::getExt($name);
+
+		if (!\JFile::write($tmpFile, $mediaContent))
+		{
+			throw new \Exception(\JText::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'), 500);
+		}
+
+		$can = $helper->canUpload(array('name' => $name, 'size' => count($mediaContent), 'tmp_name' => $tmpFile), 'com_media');
+
+		\JFile::delete($tmpFile);
+
+		if (!$can)
+		{
+			throw new \Exception(\JText::_('COM_MEDIA_ERROR_UNABLE_TO_UPLOAD_FILE'), 403);
+		}
 	}
 }

--- a/tests/unit/suites/plugins/filesystem/local/LocalAdapterTest.php
+++ b/tests/unit/suites/plugins/filesystem/local/LocalAdapterTest.php
@@ -27,7 +27,7 @@ class LocalAdapterTest extends TestCaseDatabase
 
 	/**
 	 * The image folder path related to root
-	 * 
+	 *
 	 * @var string
 	 */
 	private $imagePath = null;
@@ -102,7 +102,7 @@ class LocalAdapterTest extends TestCaseDatabase
 	/**
 	 * Test LocalAdapter::getFile with an invalid path
 	 *
-	 * @expectedException \Joomla\Component\Media\Administrator\Adapter\FileNotFoundException
+	 * @expectedException \Joomla\Component\Media\Administrator\Exception\FileNotFoundException
 	 *
 	 * @return  void
 	 */
@@ -200,7 +200,7 @@ class LocalAdapterTest extends TestCaseDatabase
 	/**
 	 * Test LocalAdapter::getFiles with an invalid path
 	 *
-	 * @expectedException \Joomla\Component\Media\Administrator\Adapter\FileNotFoundException
+	 * @expectedException \Joomla\Component\Media\Administrator\Exception\FileNotFoundException
 	 *
 	 * @return  void
 	 */
@@ -231,6 +231,26 @@ class LocalAdapterTest extends TestCaseDatabase
 	}
 
 	/**
+	 * Test LocalAdapter::createFolder with an invalid file name.
+	 *
+	 * @return  void
+	 */
+	public function testCreateFolderInvalidName()
+	{
+		// Create the adapter
+		$adapter = new LocalAdapter($this->root, $this->imagePath);
+
+		// Fetch the files from the root folder
+		$name = $adapter->createFolder('invalid"name', '/');
+
+		// Check if the illegal characters are stripped
+		$this->assertEquals('invalidname', $name);
+
+		// Check if the file exists
+		$this->assertTrue(JFolder::exists($this->root . 'invalidname'));
+	}
+
+	/**
 	 * Test LocalAdapter::createFile
 	 *
 	 * @return  void
@@ -248,6 +268,29 @@ class LocalAdapterTest extends TestCaseDatabase
 
 		// Check if the contents is correct
 		$this->assertEquals('test', file_get_contents($this->root . 'unit.txt'));
+	}
+
+	/**
+	 * Test LocalAdapter::createFile with an invalid file name.
+	 *
+	 * @return  void
+	 */
+	public function testCreateFileInvalidName()
+	{
+		// Create the adapter
+		$adapter = new LocalAdapter($this->root, $this->imagePath);
+
+		// Fetch the files from the root folder
+		$name = $adapter->createFile('invalid"name.txt', '/', 'test');
+
+		// Check if the illegal characters are stripped
+		$this->assertEquals('invalidname.txt', $name);
+
+		// Check if the file exists
+		$this->assertTrue(file_exists($this->root . 'invalidname.txt'));
+
+		// Check if the contents is correct
+		$this->assertEquals('test', file_get_contents($this->root . 'invalidname.txt'));
 	}
 
 	/**
@@ -276,7 +319,7 @@ class LocalAdapterTest extends TestCaseDatabase
 	/**
 	 * Test LocalAdapter::getFile with an invalid path
 	 *
-	 * @expectedException \Joomla\Component\Media\Administrator\Adapter\FileNotFoundException
+	 * @expectedException \Joomla\Component\Media\Administrator\Exception\FileNotFoundException
 	 *
 	 * @return  void
 	 */
@@ -317,7 +360,7 @@ class LocalAdapterTest extends TestCaseDatabase
 	/**
 	 * Test LocalAdapter::getFile with an invalid path
 	 *
-	 * @expectedException \Joomla\Component\Media\Administrator\Adapter\FileNotFoundException
+	 * @expectedException \Joomla\Component\Media\Administrator\Exception\FileNotFoundException
 	 *
 	 * @return  void
 	 */
@@ -424,7 +467,7 @@ class LocalAdapterTest extends TestCaseDatabase
 	/**
 	 * LocalAdapter::copy with invalid path
 	 *
-	 * @expectedException \Joomla\Component\Media\Administrator\Adapter\FileNotFoundException
+	 * @expectedException \Joomla\Component\Media\Administrator\Exception\FileNotFoundException
 	 * @return void
 	 */
 	public function testFileCopyInvalidPath()
@@ -433,7 +476,7 @@ class LocalAdapterTest extends TestCaseDatabase
 
 		$this->cleanRootFolder();
 
-		$this->setExpectedException('\Joomla\Component\Media\Administrator\Adapter\FileNotFoundException');
+		$this->setExpectedException('\Joomla\Component\Media\Administrator\Exception\FileNotFoundException');
 		$adapter->copy('invalid', 'invalid');
 	}
 
@@ -681,7 +724,7 @@ class LocalAdapterTest extends TestCaseDatabase
 	/**
 	 * LocalAdapter::move with an invalid path
 	 *
-	 * @expectedException \Joomla\Component\Media\Administrator\Adapter\FileNotFoundException
+	 * @expectedException \Joomla\Component\Media\Administrator\Exception\FileNotFoundException
 	 * @return void
 	 */
 	public function testMoveInvalidPath()
@@ -689,7 +732,7 @@ class LocalAdapterTest extends TestCaseDatabase
 		$adapter = new LocalAdapter($this->root, $this->imagePath);
 		$this->cleanRootFolder();
 
-		$this->setExpectedException('\Joomla\Component\Media\Administrator\Adapter\FileNotFoundException');
+		$this->setExpectedException('\Joomla\Component\Media\Administrator\Exception\FileNotFoundException');
 		$adapter->move('invalid', 'invalid-new');
 	}
 

--- a/tests/unit/suites/plugins/filesystem/local/PlgFileSystemLocalTest.php
+++ b/tests/unit/suites/plugins/filesystem/local/PlgFileSystemLocalTest.php
@@ -86,7 +86,7 @@ class PlgFileSystemLocalTest extends TestCaseDatabase
 	 */
 	public function testOnFileSystemGetAdapters()
 	{
-		$adapter = $this->pluginClass->onFileSystemGetAdapters();
+		$adapter = $this->pluginClass->getAdapters();
 		self::containsOnlyInstancesOf(\Joomla\Plugin\Filesystem\Local\Adapter\LocalAdapter::class, $adapter);
 	}
 }


### PR DESCRIPTION
The logic which file names are allowed should be handled and managed by the adapter and not the controller. This prevents us from situations on restrictive adapters when they do not allow certain file names that they can decide the filename and do not abort the file upload. The logic is changed the way that when a file or folder is created the file name is returned by the adapter of the new file or folder which get propagated to the client then. Similar as Google is doing it.

~Additionally files with spaces are allowed as I don't see a valid reason why it shouldn't work.~