### PR TITLE
Don't strip out special characters for display

### DIFF
--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -308,7 +308,7 @@ class LocalAdapter implements AdapterInterface
 		// Set the values
 		$obj            = new \stdClass;
 		$obj->type      = $isDir ? 'dir' : 'file';
-		$obj->name      = basename($path);
+		$obj->name      = $this->getFileName($path);
 		$obj->path      = str_replace($this->rootPath, '/', $path);
 		$obj->localpath = $path;
 		$obj->extension = !$isDir ? \JFile::getExt($obj->name) : '';
@@ -396,7 +396,7 @@ class LocalAdapter implements AdapterInterface
 			throw new FileNotFoundException;
 		}
 
-		$name     = basename($destinationPath);
+		$name     = $this->getFileName($destinationPath);
 		$safeName = $this->getSafeName($name);
 
 		// If the safe name is different normalise the file name
@@ -436,7 +436,7 @@ class LocalAdapter implements AdapterInterface
 		if (is_dir($destinationPath))
 		{
 			// If the destination is a folder we create a file with the same name as the source
-			$destinationPath = $destinationPath . '/' . basename($sourcePath);
+			$destinationPath = $destinationPath . '/' . $this->getFileName($sourcePath);
 		}
 
 		if (file_exists($destinationPath) && !$force)
@@ -506,7 +506,7 @@ class LocalAdapter implements AdapterInterface
 			throw new FileNotFoundException;
 		}
 
-		$name     = basename($destinationPath);
+		$name     = $this->getFileName($destinationPath);
 		$safeName = $this->getSafeName($name);
 
 		// If the safe name is different normalise the file name
@@ -544,7 +544,7 @@ class LocalAdapter implements AdapterInterface
 		if (is_dir($destinationPath))
 		{
 			// If the destination is a folder we create a file with the same name as the source
-			$destinationPath = $destinationPath . '/' . basename($sourcePath);
+			$destinationPath = $destinationPath . '/' . $this->getFileName($sourcePath);
 		}
 
 		if (file_exists($destinationPath) && !$force)
@@ -681,7 +681,7 @@ class LocalAdapter implements AdapterInterface
 		$files = glob($pattern, $flags);
 		foreach (glob(dirname($pattern) . '/*', GLOB_ONLYDIR|GLOB_NOSORT) as $dir)
 		{
-			$files = array_merge($files, $this->rglob($dir . '/' . basename($pattern), $flags));
+			$files = array_merge($files, $this->rglob($dir . '/' . $this->getFileName($pattern), $flags));
 		}
 
 		return $files;
@@ -784,5 +784,24 @@ class LocalAdapter implements AdapterInterface
 		{
 			throw new \Exception(\JText::_('COM_MEDIA_ERROR_UNABLE_TO_UPLOAD_FILE'), 403);
 		}
+	}
+
+	/**
+	 * Returns the file name of the given path.
+	 *
+	 * @param   string  $path The path
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception
+	 */
+	private function getFileName($path)
+	{
+		// Basename does not work here as it strips out certain characters like upper case umlaut u
+		$path = explode(DIRECTORY_SEPARATOR, $path);
+
+		// Return the last element
+		return array_pop($path);
 	}
 }


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla-projects/media-manager-improvement/pull/448#issuecomment-340257963.

### Summary of Changes
If a file is uploaded trough FTP with the name Über-größen_ länge.jpg, then it becomes ber-gren_ lnge.jpg. This is due some stripping in the basename function of PHP because of locale issues, this pr just stripps out the last part of the path.

### Testing Instructions
Upload an image with the name "Über-größen_ länge.jpg" trough FTP to the images directory.

### Expected result
Image is displayed with the name Über-größen_ länge.jpg.

### Actual result
Ü is stripped out from the image name Über-größen_ länge.jpg.