### PR TITLE
Detects correctly if the files exists in API model

### DIFF
--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -221,7 +221,7 @@ class ApiModel extends BaseDatabaseModel
 		}
 
 		// Check if the file exists
-		if ($file && !$override)
+		if (isset($file) && !$override)
 		{
 			throw new FileExistsException;
 		}


### PR DESCRIPTION
As reported in #468, an error is thrown. This pr adds the necessary check.