### PR TITLE
[4.0] Fix filename not displaying properly in media manager (Windows)

### DIFF
--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -820,7 +820,9 @@ class LocalAdapter implements AdapterInterface
 	 * @throws  \Exception
 	 */
 	private function getFileName($path)
-	{
+	{	
+		$path = \JPath::clean($path);
+		
 		// Basename does not work here as it strips out certain characters like upper case umlaut u
 		$path = explode(DIRECTORY_SEPARATOR, $path);
 


### PR DESCRIPTION
###Issue

File and folder name not displaying properly.
The file path is showing in the place of the filename.

On windows

### Summary of Changes

Changes in:
<code>plugins/filesystem/local/Adapter/LocalAdapter.php</code>

<code>$path = \JPath::clean($path);</code>

added before explode


### Testing Instructions
Test this on  <b>On windows</b>
Open media manager and check out.


### Expected result
![1](https://user-images.githubusercontent.com/30978328/34522180-77df6822-f0b7-11e7-8ede-bb0a8b7b5e12.PNG)



### Actual result

![2](https://user-images.githubusercontent.com/30978328/34522186-7abb5a06-f0b7-11e7-8830-9a9d507f95c9.PNG)


### Documentation Changes Required


  
  
  