### PR TITLE
[4.0] Fix unexpected error on rename of file or folder

### DIFF
--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -439,6 +439,9 @@ class LocalAdapter implements AdapterInterface
 			$this->copyFile($sourcePath, $destinationPath, $force);
 		}
 
+		//get relative path
+		$destinationPath = str_replace($this->rootPath, '', $destinationPath);
+
 		return $destinationPath;
 	}
 
@@ -546,6 +549,9 @@ class LocalAdapter implements AdapterInterface
 		{
 			$this->moveFile($sourcePath, $destinationPath, $force);
 		}
+
+		//get relative path
+		$destinationPath = str_replace($this->rootPath, '', $destinationPath);
 
 		return $destinationPath;
 	}

--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -820,7 +820,9 @@ class LocalAdapter implements AdapterInterface
 	 * @throws  \Exception
 	 */
 	private function getFileName($path)
-	{
+	{	
+		$path = \JPath::clean($path);
+		
 		// Basename does not work here as it strips out certain characters like upper case umlaut u
 		$path = explode(DIRECTORY_SEPARATOR, $path);
 

--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -827,8 +827,6 @@ class LocalAdapter implements AdapterInterface
 	 */
 	private function getFileName($path)
 	{	
-		$path = \JPath::clean($path);
-		
 		// Basename does not work here as it strips out certain characters like upper case umlaut u
 		$path = explode(DIRECTORY_SEPARATOR, $path);
 

--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -826,7 +826,7 @@ class LocalAdapter implements AdapterInterface
 	 * @throws  \Exception
 	 */
 	private function getFileName($path)
-	{	
+	{
 		// Basename does not work here as it strips out certain characters like upper case umlaut u
 		$path = explode(DIRECTORY_SEPARATOR, $path);
 


### PR DESCRIPTION
Pull Request for Issue #487 

### Summary of Changes
Changes in:
<code>plugins/filesystem/local/Adapter/LocalAdapter.php</code>
In move and copy function.
We return relative path not absolute path


### Testing Instructions
Try to rename file and folder.


### Expected result
No error comes out. Rename success


### Actual result
Error comes out


### Documentation Changes Required

