### PR TITLE
Aspect Ratio values

### DIFF
--- a/plugins/media-action/crop/form/crop.xml
+++ b/plugins/media-action/crop/form/crop.xml
@@ -64,9 +64,9 @@
 			class=""
 			default=""
 			>
-			<option value="1.7777777777777777">16 / 9</option>
-			<option value="1.3333333333333333">4 / 3</option>
-			<option value="0.6666666666666666">2 / 3</option>
+			<option value="1.7777777777777777">16:9</option>
+			<option value="1.3333333333333333">4:3</option>
+			<option value="0.6666666666666666">3:2</option>
 			<option value="">PLG_MEDIA-ACTION_CROP_PARAM_RATIO_RESET</option>
 		</field>
 	</fieldset>


### PR DESCRIPTION
Aspect ratio are usually written 4:3 not 4/3
I would also change 2/3 to 3/2 so that all the ratios are in the same orientation
<img width="403" alt="screenshotr10-56-32" src="https://user-images.githubusercontent.com/1296369/35094802-52d66e62-fc3e-11e7-9eb4-9a05d3845bb9.png">

screenshot from https://calculateaspectratio.com/
