### PR TITLE
Bug mimetype in resize.js and rotate.js

### DIFF
--- a/media/plg_media-action_resize/js/resize.js
+++ b/media/plg_media-action_resize/js/resize.js
@@ -22,7 +22,7 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
 		canvas.getContext("2d").drawImage(image, 0, 0, width, height);
 
 		// The format
-		var format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
+		var format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
 
 		// The quality
 		var quality = document.getElementById('jform_resize_quality').value;

--- a/media/plg_media-action_rotate/js/rotate.js
+++ b/media/plg_media-action_rotate/js/rotate.js
@@ -35,7 +35,6 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
 		// The format
 		var format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
 
-
 		// The quality
 		var quality = document.getElementById('jform_rotate_quality').value;
 

--- a/media/plg_media-action_rotate/js/rotate.js
+++ b/media/plg_media-action_rotate/js/rotate.js
@@ -33,7 +33,8 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
 		ctx.drawImage(image, -image.width / 2, -image.height / 2);
 
 		// The format
-		var format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
+		var format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
+
 
 		// The quality
 		var quality = document.getElementById('jform_rotate_quality').value;


### PR DESCRIPTION
Use the same code as in crop.js for the file format (used for the mime type)
myimage.jpeg becomes png encoded as jpg is invalid.
I couldn't find out if this has any consequences but it sure could.