### PR TITLE
Use strlen instead of count to determine the media content size

### DIFF
--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -807,7 +807,7 @@ class LocalAdapter implements AdapterInterface
 			throw new \Exception(Text::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'), 500);
 		}
 
-		$can = $helper->canUpload(array('name' => $name, 'size' => count($mediaContent), 'tmp_name' => $tmpFile), 'com_media');
+		$can = $helper->canUpload(array('name' => $name, 'size' => strlen($mediaContent), 'tmp_name' => $tmpFile), 'com_media');
 
 		\JFile::delete($tmpFile);
 


### PR DESCRIPTION
Pull Request for Issue #521.

### Summary of Changes
On PHP 7.2 count is more strict and need an array or countable object. Strlen is correctly determining the size of a string.