### PR TITLE
Use the standard button as apply doesn't exist anymore

### DIFF
--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -475,7 +475,7 @@ abstract class ToolbarHelper
 		$bar = Toolbar::getInstance('toolbar');
 
 		// Add an apply button
-		$bar->appendButton('Apply', 'apply', $alt, $task, false);
+		$bar->appendButton('Standard', 'apply', $alt, $task, false);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #544.

### Summary of Changes
Fixes the button type for the apply button.