### PR TITLE
Add save events for content plugins

### DIFF
--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -510,8 +510,8 @@ class ApiModel extends BaseDatabaseModel
 	 * @param   callable  $callback  The callback
 	 *
 	 * @return  CMSObject
-	 * @throws  \Exception
 	 *
+	 * @throws  \Exception
 	 * @since   __DEPLOY_VERSION__
 	 */
 	private function triggerEvent(string $adapter, string $name, string $path, $data, callable $callback)

--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -228,7 +228,12 @@ class ApiModel extends BaseDatabaseModel
 			throw new FileExistsException;
 		}
 
-		$object = $this->triggerEvent($adapter, $name, $path, 0, function ($object)
+		$object = $this->triggerEvent(
+			$adapter,
+			$name,
+			$path,
+			0,
+			function ($object)
 			{
 				$object->name = $this->getAdapter($object->adapter)->createFolder($object->name, $object->path);
 			}
@@ -276,7 +281,12 @@ class ApiModel extends BaseDatabaseModel
 			throw new InvalidPathException;
 		}
 
-		$object = $this->triggerEvent($adapter, $name, $path, $data, function ($object)
+		$object = $this->triggerEvent(
+			$adapter,
+			$name,
+			$path,
+			$data,
+			function ($object)
 			{
 				$object->name = $this->getAdapter($object->adapter)->createFile($object->name, $object->path, $object->data);
 			}
@@ -308,7 +318,12 @@ class ApiModel extends BaseDatabaseModel
 			throw new InvalidPathException;
 		}
 
-		$this->triggerEvent($adapter, $name, $path, $data, function ($object)
+		$this->triggerEvent(
+			$adapter,
+			$name,
+			$path,
+			$data,
+			function ($object)
 			{
 				$this->getAdapter($object->adapter)->updateFile($object->name, $object->path, $object->data);
 			}

--- a/administrator/components/com_media/Model/ApiModel.php
+++ b/administrator/components/com_media/Model/ApiModel.php
@@ -13,7 +13,9 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Media\Administrator\Adapter\AdapterInterface;
 use Joomla\Component\Media\Administrator\Exception\FileExistsException;
@@ -226,7 +228,13 @@ class ApiModel extends BaseDatabaseModel
 			throw new FileExistsException;
 		}
 
-		return $this->getAdapter($adapter)->createFolder($name, $path);
+		$object = $this->triggerEvent($adapter, $name, $path, 0, function ($object)
+			{
+				$object->name = $this->getAdapter($object->adapter)->createFolder($object->name, $object->path);
+			}
+		);
+
+		return $object->name;
 	}
 
 	/**
@@ -268,7 +276,13 @@ class ApiModel extends BaseDatabaseModel
 			throw new InvalidPathException;
 		}
 
-		return $this->getAdapter($adapter)->createFile($name, $path, $data);
+		$object = $this->triggerEvent($adapter, $name, $path, $data, function ($object)
+			{
+				$object->name = $this->getAdapter($object->adapter)->createFile($object->name, $object->path, $object->data);
+			}
+		);
+
+		return $object->name;
 	}
 
 	/**
@@ -294,7 +308,11 @@ class ApiModel extends BaseDatabaseModel
 			throw new InvalidPathException;
 		}
 
-		$this->getAdapter($adapter)->updateFile($name, $path, $data);
+		$this->triggerEvent($adapter, $name, $path, $data, function ($object)
+			{
+				$this->getAdapter($object->adapter)->updateFile($object->name, $object->path, $object->data);
+			}
+		);
 	}
 
 	/**
@@ -460,5 +478,53 @@ class ApiModel extends BaseDatabaseModel
 
 		// Check if the extension exists in the allowed extensions
 		return in_array($extension, $this->allowedExtensions);
+	}
+
+	/**
+	 * Triggers the onContentBeforeSave and onContentAfterSave event when calling the
+	 * given callable.
+	 *
+	 * If the onContentBeforeSave contains false, the operation will be aborted and an exception thrown.
+	 *
+	 * The object will be returned which got sent as part of the event.
+	 *
+	 * @param   string    $adapter   The adapter
+	 * @param   string    $name      The name
+	 * @param   string    $path      The path
+	 * @param   binary    $data      The binary data
+	 * @param   callable  $callback  The callback
+	 *
+	 * @return  CMSObject
+	 * @throws  \Exception
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function triggerEvent(string $adapter, string $name, string $path, $data, callable $callback)
+	{
+		$app = Factory::getApplication();
+
+		$object            = new CMSObject;
+		$object->adapter   = $adapter;
+		$object->name      = $name;
+		$object->path      = $path;
+		$object->data      = $data;
+		$object->extension = strtolower(File::getExt($name));
+		$object->type      = $object->extension ? 'file' : 'dir';
+
+		// Also include the filesystem plugins, perhaps they support batch processing too
+		PluginHelper::importPlugin('media-action');
+
+		$result = $app->triggerEvent('onContentBeforeSave', array('com_media.' . $object->type, $object, true));
+
+		if (in_array(false, $result, true))
+		{
+			throw new \Exception($object->getError());
+		}
+
+		$callback($object);
+
+		$app->triggerEvent('onContentAfterSave', array('com_media.' . $object->type, $object, true));
+
+		return $object;
 	}
 }

--- a/administrator/language/en-GB/en-GB.plg_media-action_resize.ini
+++ b/administrator/language/en-GB/en-GB.plg_media-action_resize.ini
@@ -4,6 +4,12 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_MEDIA-ACTION_RESIZE="Media Action - Resize"
+PLG_MEDIA-ACTION_RESIZE_BATCH_DESC="Settings for server side actions when images got created."
+PLG_MEDIA-ACTION_RESIZE_BATCH_LABEL="Batch Settings"
+PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_LABEL="Image Max Width"
+PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_DESC="The maximum width an image can have. When empty, no resizing is performed."
+PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_LABEL="Image Max Width"
+PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_DESC="The maximum width an image can have. When empty, no resizing is performed."
 PLG_MEDIA-ACTION_RESIZE_LABEL="Resize"
 PLG_MEDIA-ACTION_RESIZE_PARAM_WIDTH="Width"
 PLG_MEDIA-ACTION_RESIZE_PARAM_HEIGHT="Height"

--- a/administrator/language/en-GB/en-GB.plg_media-action_resize.ini
+++ b/administrator/language/en-GB/en-GB.plg_media-action_resize.ini
@@ -4,12 +4,12 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_MEDIA-ACTION_RESIZE="Media Action - Resize"
-PLG_MEDIA-ACTION_RESIZE_BATCH_DESC="Settings for server side actions when images got created."
+PLG_MEDIA-ACTION_RESIZE_BATCH_DESC="Settings for server side actions when images are created."
 PLG_MEDIA-ACTION_RESIZE_BATCH_LABEL="Batch Settings"
-PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_LABEL="Image Max Width"
-PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_DESC="The maximum width an image can have. When empty, no resizing is performed."
+PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_LABEL="Image Max Height"
+PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_DESC="The maximum height of an image to resize. When empty, no resizing is performed."
 PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_LABEL="Image Max Width"
-PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_DESC="The maximum width an image can have. When empty, no resizing is performed."
+PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_DESC="The maximum width of an image to resize. When empty, no resizing is performed."
 PLG_MEDIA-ACTION_RESIZE_LABEL="Resize"
 PLG_MEDIA-ACTION_RESIZE_PARAM_WIDTH="Width"
 PLG_MEDIA-ACTION_RESIZE_PARAM_HEIGHT="Height"

--- a/plugins/media-action/resize/resize.php
+++ b/plugins/media-action/resize/resize.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use \Joomla\Image\Image;
+
 /**
  * Media Manager Resize Action
  *
@@ -16,4 +18,64 @@ defined('_JEXEC') or die;
  */
 class PlgMediaActionResize extends \Joomla\Component\Media\Administrator\Plugin\MediaActionPlugin
 {
+	/**
+	 * The save event.
+	 *
+	 * @param   string   $context  The context
+	 * @param   object   $item     The item
+	 * @param   boolean  $isNew    Is new item
+	 * @param   array    $data     The validated data
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onContentBeforeSave($context, $item, $isNew, $data = array())
+	{
+		if ($context != 'com_media.file')
+		{
+			return;
+		}
+
+		if (!$this->params->get('batch_width') && !$this->params->get('batch_height'))
+		{
+			return;
+		}
+
+		if (!in_array($item->extension, ['jpg', 'jpeg', 'png', 'gif']))
+		{
+			return;
+		}
+
+		$imgObject = new Image(imagecreatefromstring($item->data));
+
+		if ($imgObject->getWidth() < $this->params->get('batch_width', 0)
+			&& $imgObject->getHeight() < $this->params->get('batch_height', 0))
+		{
+			return;
+		}
+
+		$imgObject->resize(
+			$this->params->get('batch_width', 0),
+			$this->params->get('batch_height', 0),
+			false,
+			Image::SCALE_INSIDE
+		);
+
+		$type = IMAGETYPE_JPEG;
+
+		switch ($item->extension)
+		{
+			case 'gif':
+				$type = IMAGETYPE_GIF;
+				break;
+			case 'png':
+				$type = IMAGETYPE_PNG;
+		}
+
+		ob_start();
+		$imgObject->toFile(null, $type);
+		$item->data =  ob_get_contents();
+		ob_end_clean();
+	}
 }

--- a/plugins/media-action/resize/resize.php
+++ b/plugins/media-action/resize/resize.php
@@ -75,7 +75,7 @@ class PlgMediaActionResize extends \Joomla\Component\Media\Administrator\Plugin\
 
 		ob_start();
 		$imgObject->toFile(null, $type);
-		$item->data =  ob_get_contents();
+		$item->data = ob_get_contents();
 		ob_end_clean();
 	}
 }

--- a/plugins/media-action/resize/resize.xml
+++ b/plugins/media-action/resize/resize.xml
@@ -17,4 +17,26 @@
 		<language tag="en-GB">en-GB.plg_media-action_resize.ini</language>
 		<language tag="en-GB">en-GB.plg_media-action_resize.sys.ini</language>
 	</languages>
+	<config>
+		<fields name="params">
+			<fieldset name="batch" label="PLG_MEDIA-ACTION_RESIZE_BATCH_LABEL" description="PLG_MEDIA-ACTION_RESIZE_BATCH_DESC">
+				<field
+						name="batch_width"
+						type="text"
+						label="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_LABEL"
+						descripton="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_DESC"
+						addonAfter="px"
+						filter="int"
+				/>
+				<field
+						name="batch_height"
+						type="text"
+						label="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_LABEL"
+						descripton="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_DESC"
+						addonAfter="px"
+						filter="int"
+				/>
+			</fieldset>
+		</fields>
+	</config>
 </extension>

--- a/plugins/media-action/resize/resize.xml
+++ b/plugins/media-action/resize/resize.xml
@@ -21,20 +21,20 @@
 		<fields name="params">
 			<fieldset name="batch" label="PLG_MEDIA-ACTION_RESIZE_BATCH_LABEL" description="PLG_MEDIA-ACTION_RESIZE_BATCH_DESC">
 				<field
-						name="batch_width"
-						type="text"
-						label="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_LABEL"
-						descripton="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_DESC"
-						addonAfter="px"
-						filter="int"
+					name="batch_width"
+					type="text"
+					label="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_LABEL"
+					descripton="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_WIDTH_DESC"
+					addonAfter="px"
+					filter="integer"
 				/>
 				<field
-						name="batch_height"
-						type="text"
-						label="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_LABEL"
-						descripton="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_DESC"
-						addonAfter="px"
-						filter="int"
+					name="batch_height"
+					type="text"
+					label="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_LABEL"
+					descripton="PLG_MEDIA-ACTION_RESIZE_BATCH_MAX_HEIGHT_DESC"
+					addonAfter="px"
+					filter="integer"
 				/>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
Pull Request for Issue #523.

### Summary of Changes
A `onContentBeforeSave` and `onContentAfterSave`event gets triggered when a file is created or updated or when a folder is created. This includes also cloud adapters. The file data which is uploaded is sent in the event which can be modified by a plugin.

This pr includes also two new batch settings for the resize plugin where the admin can define a max width and height for any image which gets uploaded.

### Testing Instructions
- Set a max width or height in the resize plugin.
- Upload an image which is bigger than these two values.

### Expected result
Image get resized to be not bigger than the defined values.

### Actual result
No automatic resize is possible.